### PR TITLE
feat(frontend): redesign login page layout

### DIFF
--- a/front-end/src/app/login/login.component.css
+++ b/front-end/src/app/login/login.component.css
@@ -1,0 +1,165 @@
+:host {
+  display: block;
+}
+
+.login-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background:
+    linear-gradient(120deg, rgba(37, 99, 235, 0.82), rgba(125, 211, 252, 0.72)),
+    url('https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=2070&q=80') center / cover fixed;
+}
+
+.login-card {
+  width: min(980px, 100%);
+  min-height: 610px;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  background-color: #fff;
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.28);
+}
+
+.brand-panel {
+  background: linear-gradient(170deg, #1d4ed8, #2563eb 45%, #0ea5e9);
+  color: #fff;
+  padding: 2.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.brand-badge {
+  width: fit-content;
+  margin: 0;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.brand-panel h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.4rem);
+  line-height: 1.15;
+}
+
+.brand-text {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.brand-panel ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.form-panel {
+  padding: 2.4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.logo {
+  margin-bottom: 0.4rem;
+}
+
+.form-panel h2 {
+  margin: 0;
+  color: #111827;
+}
+
+.subtitle {
+  margin: 0.4rem 0 1.6rem;
+  color: #6b7280;
+}
+
+.login-form {
+  width: min(380px, 100%);
+  display: grid;
+  gap: 1rem;
+}
+
+.login-form label {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.92rem;
+  color: #374151;
+}
+
+.login-form input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 0.65rem;
+  padding: 0.72rem 0.8rem;
+  font-size: 0.95rem;
+}
+
+.login-form input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.password-input {
+  position: relative;
+}
+
+.password-input button {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.forgot-password {
+  justify-self: end;
+  text-decoration: none;
+  font-size: 0.9rem;
+  color: #2563eb;
+}
+
+.login-btn {
+  margin-top: 0.4rem;
+  border: none;
+  border-radius: 0.65rem;
+  padding: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  background: linear-gradient(120deg, #2563eb, #1d4ed8);
+}
+
+.signup-link {
+  margin-top: 1.3rem;
+  color: #6b7280;
+}
+
+.signup-link a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .login-card {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-panel {
+    padding: 2rem;
+  }
+}

--- a/front-end/src/app/login/login.component.html
+++ b/front-end/src/app/login/login.component.html
@@ -1,39 +1,53 @@
-<div class="h-screen bg-cover bg-center bg-fixed flex items-center justify-center p-4"
-     style="background-image: url('https://images.unsplash.com/photo-1482731910308-31e96e5d1d28?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D');">
-    <div class="bg-white rounded-2xl shadow-lg flex flex-col-reverse md:flex-row max-w-4xl w-full mx-4 md:mx-0">
-        <!-- Section gauche (en bas sur mobile, à gauche sur desktop) -->
-        <div class="bg-blue-500 text-white p-8 rounded-b-2xl md:rounded-l-2xl md:rounded-br-none md:w-1/2 flex flex-col justify-center">
-            <h1 class="text-3xl font-bold mb-4 text-center">time2wish</h1>
-            <p class="text-sm text-justify">
-                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Id vel, laboriosam voluptatum repudiandae recusandae obcaecati, quo quas asperiores atque perspiciatis laudantium nostrum! Consectetur cupiditate natus blanditiis eveniet, dolores dicta quo.
-                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Id vel, laboriosam voluptatum repudiandae recusandae obcaecati, quo quas asperiores atque perspiciatis laudantium nostrum! Consectetur cupiditate natus blanditiis eveniet, dolores dicta quo.
-                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Id vel, laboriosam voluptatum repudiandae recusandae obcaecati, quo quas asperiores atque perspiciatis laudantium nostrum! Consectetur cupiditate natus blanditiis eveniet, dolores dicta quo.
-                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Id vel, laboriosam voluptatum repudiandae recusandae obcaecati, quo quas asperiores atque perspiciatis laudantium nostrum! Consectetur cupiditate natus blanditiis eveniet, dolores dicta quo.
-            </p>
-        </div>
-        <!-- Section droite (en haut sur mobile, à droite sur desktop) -->
-        <div class="p-8 md:w-1/2 flex flex-col items-center justify-center">
-            <img src="time2wish-logo.png" width="160" height="160" alt="logo time2wish" class="mb-4">
-            <h2 class="text-xl font-semibold mb-4">Login</h2>
-            <div class="w-full">
-                <div class="flex flex-col space-y-3 md:flex-row md:space-x-2 md:space-y-0 mb-3">
-                    <input type="email" placeholder="Email" class="w-full md:w-1/2 p-2 border border-gray-300 rounded">
-                    <div class="relative w-full md:w-1/2">
-                        <input [type]="showPassword ? 'text' : 'password'" placeholder="Password" class="w-full p-2 border border-gray-300 rounded">
-                        <span class="absolute inset-y-0 right-3 flex items-center cursor-pointer" (click)="togglePassword()">
-                            <i class="fa" [ngClass]="showPassword ? 'fa-eye-slash' : 'fa-eye'"></i>
-                        </span>
-                    </div>
-                </div>
-                <button class="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600" (click)="onLogin()">Login</button>
-                <div class="w-full text-center mb-4">
-                    <a href="#" class="text-blue-500 text-sm">Forgotten password ?</a>
-                </div>
-            </div>
-            <div class="text-sm mb-4">
-                <span>Don't have an account yet? </span>
-                <a href="#" class="text-blue-500">Sign up</a>
-            </div>
-        </div>
+<div class="login-page">
+  <section class="login-card">
+    <aside class="brand-panel">
+      <p class="brand-badge">time2wish</p>
+      <h1>Never miss a birthday again.</h1>
+      <p class="brand-text">
+        Centralisez les dates importantes, programmez des rappels personnalisés
+        et préparez des messages attentionnés pour chaque personne qui compte.
+      </p>
+      <ul>
+        <li>Rappels automatiques</li>
+        <li>Idées de cadeaux et messages</li>
+        <li>Vue claire des prochains anniversaires</li>
+      </ul>
+    </aside>
+
+    <div class="form-panel">
+      <img src="time2wish-logo.png" width="120" height="120" alt="time2wish logo" class="logo" />
+      <h2>Connexion</h2>
+      <p class="subtitle">Heureux de vous revoir 👋</p>
+
+      <form class="login-form" (submit)="$event.preventDefault(); onLogin()">
+        <label>
+          <span>Email</span>
+          <input type="email" placeholder="john.doe@email.com" autocomplete="email" required />
+        </label>
+
+        <label>
+          <span>Mot de passe</span>
+          <div class="password-input">
+            <input
+              [type]="showPassword ? 'text' : 'password'"
+              placeholder="••••••••"
+              autocomplete="current-password"
+              required
+            />
+            <button type="button" (click)="togglePassword()" [attr.aria-label]="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'">
+              {{ showPassword ? '🙈' : '👁️' }}
+            </button>
+          </div>
+        </label>
+
+        <a class="forgot-password" href="#">Mot de passe oublié ?</a>
+
+        <button class="login-btn" type="submit">Se connecter</button>
+      </form>
+
+      <p class="signup-link">
+        Pas encore de compte ? <a href="#">Créer un compte</a>
+      </p>
     </div>
+  </section>
 </div>


### PR DESCRIPTION
### Motivation
- Créer une page de connexion moderne, accessible et responsive pour l'application Time2Wish.
- Remplacer le contenu provisoire par un design deux-panneaux (branding + formulaire) et améliorer l'ergonomie du formulaire (soumission et visibilité du mot de passe).

### Description
- Reconstructed markup in `front-end/src/app/login/login.component.html` to a two-panel layout with a branding aside and a semantic `<form>` for authentication, including a password visibility toggle with ARIA label.
- Added component-level styling in `front-end/src/app/login/login.component.css` for spacing, typography, focus states, buttons, inputs and responsive behavior (mobile breakpoint at 900px).
- Replaced placeholder text with French product copy and improved form semantics (required inputs, autocomplete attributes, submit handling calling `onLogin()`).
- Performed a visual verification by serving the app and capturing a screenshot of the updated `/login` page.

### Testing
- Ran `npm run start -- --host 0.0.0.0 --port 4200` and the dev server served the application successfully and allowed a Playwright screenshot of `/login` to be taken.
- Ran `npm run build` which failed in this environment due to Google Fonts inlining returning HTTP 403.
- Ran `npm run test -- --watch=false --browsers=ChromeHeadless` which failed due to an existing Tailwind/PostCSS configuration issue in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ba0950ac83328e9f02aced6f288e)