### PR TITLE
Fix birthday list scrolling and sticky paginator/footer

### DIFF
--- a/front-end/src/app/components/birthday-table/birthday-table.component.html
+++ b/front-end/src/app/components/birthday-table/birthday-table.component.html
@@ -1,5 +1,5 @@
-<div class="flex h-full min-h-0 flex-col overflow-hidden rounded-lg mat-elevation-z8">
-  <div class="min-h-0 flex-1 overflow-y-auto">
+<div class="flex flex-col min-h-0 max-h-full overflow-hidden">
+  <div class="min-h-0 flex-1 overflow-y-auto mat-elevation-z8">
     <table mat-table [dataSource]="dataSource" matSort class="w-full">
       <!-- Colonne Photo (non triable) -->
       <ng-container matColumnDef="photo">
@@ -199,7 +199,7 @@
     [pageSize]="pageSize"
     showFirstLastButtons
     aria-label="Select page of birthdays"
-    class="sticky bottom-0 z-10 border-t bg-white"
+    class="sticky bottom-0 z-10 border-t"
   >
   </mat-paginator>
 </div>

--- a/front-end/src/app/components/birthday-table/birthday-table.component.html
+++ b/front-end/src/app/components/birthday-table/birthday-table.component.html
@@ -1,5 +1,5 @@
-<div class="flex flex-col min-h-0 max-h-full overflow-hidden">
-  <div  class=" flex-1 overflow-y-auto mat-elevation-z8">
+<div class="flex h-full min-h-0 flex-col overflow-hidden rounded-lg mat-elevation-z8">
+  <div class="min-h-0 flex-1 overflow-y-auto">
     <table mat-table [dataSource]="dataSource" matSort class="w-full">
       <!-- Colonne Photo (non triable) -->
       <ng-container matColumnDef="photo">
@@ -199,7 +199,7 @@
     [pageSize]="pageSize"
     showFirstLastButtons
     aria-label="Select page of birthdays"
-    class="border-t"
+    class="sticky bottom-0 z-10 border-t bg-white"
   >
   </mat-paginator>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -1,11 +1,11 @@
-<div class="mt-4 flex-1 overflow-hidden bg-white rounded-lg shadow-lg p-4 mb-4" *transloco="let t">
+<div class="mt-4 min-h-0 flex-1 overflow-hidden bg-white rounded-lg shadow-lg p-4" *transloco="let t">
   @if (isLoading) {
     <div class="bg-white flex flex-col flex-1 items-center justify-center h-full">
       <mat-spinner diameter="50" color="primary"></mat-spinner>
       <p class="text-gray-600 text-sm mt-2">{{ t('anniversary.loading') }}</p>
     </div>
   } @else {
-    <div class="flex flex-col h-full">
+    <div class="flex min-h-0 flex-col h-full">
       @if (viewMode === 'table') {
         <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 p-4 border-b border-gray-200 shrink-0">
           <div class="flex justify-center flex-wrap gap-2">
@@ -15,10 +15,10 @@
         </div>
       }
 
-      <div class="flex-1 overflow-y-auto">
+      <div class="min-h-0 flex-1 overflow-y-auto">
         @if (hasBirthdays) {
           @if (viewMode === 'table') {
-            <app-birthday-table class="flex-1" [birthdays]="filteredBirthdays" (edit)="birthdayEdit.emit()" (delete)="birthdayDelete.emit($event)" (refresh)="refresh.emit()"></app-birthday-table>
+            <app-birthday-table class="block h-full" [birthdays]="filteredBirthdays" (edit)="birthdayEdit.emit()" (delete)="birthdayDelete.emit($event)" (refresh)="refresh.emit()"></app-birthday-table>
           } @else {
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
               @for (item of filteredBirthdays; track item.id) {

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -1,4 +1,4 @@
-<div class="mt-4 min-h-0 flex-1 overflow-hidden bg-white rounded-lg shadow-lg p-4" *transloco="let t">
+<div class="mt-4 min-h-0 flex-1 overflow-hidden bg-white rounded-lg shadow-lg p-4 mb-4" *transloco="let t">
   @if (isLoading) {
     <div class="bg-white flex flex-col flex-1 items-center justify-center h-full">
       <mat-spinner diameter="50" color="primary"></mat-spinner>
@@ -18,7 +18,7 @@
       <div class="min-h-0 flex-1 overflow-y-auto">
         @if (hasBirthdays) {
           @if (viewMode === 'table') {
-            <app-birthday-table class="block h-full" [birthdays]="filteredBirthdays" (edit)="birthdayEdit.emit()" (delete)="birthdayDelete.emit($event)" (refresh)="refresh.emit()"></app-birthday-table>
+            <app-birthday-table class="flex-1 min-h-0" [birthdays]="filteredBirthdays" (edit)="birthdayEdit.emit()" (delete)="birthdayDelete.emit($event)" (refresh)="refresh.emit()"></app-birthday-table>
           } @else {
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
               @for (item of filteredBirthdays; track item.id) {

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -2,7 +2,7 @@
   <app-aside-nav-bar></app-aside-nav-bar>
 
   <div class="h-screen w-screen flex items-center justify-center bg-gray-200 overflow-hidden">
-    <main class="h-full w-full min-h-0 flex flex-col p-4 shadow-lg rounded-lg gap-2 overflow-hidden">
+    <main class="h-full w-full min-h-0 flex flex-col p-4 shadow-lg rounded-lg overflow-hidden">
       <app-landing-page-header
         [viewMode]="viewMode"
         [activeButton]="activeButton"
@@ -40,7 +40,7 @@
         (refresh)="refresh.emit()"
       ></app-landing-page-content>
 
-      <div class="shrink-0 sticky bottom-0 z-20">
+      <div class="shrink-0">
         <app-footer></app-footer>
       </div>
     </main>

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -2,7 +2,7 @@
   <app-aside-nav-bar></app-aside-nav-bar>
 
   <div class="h-screen w-screen flex items-center justify-center bg-gray-200 overflow-hidden">
-    <main class="h-full w-full flex flex-col p-4 shadow-lg rounded-lg">
+    <main class="h-full w-full min-h-0 flex flex-col p-4 shadow-lg rounded-lg gap-2 overflow-hidden">
       <app-landing-page-header
         [viewMode]="viewMode"
         [activeButton]="activeButton"
@@ -40,7 +40,9 @@
         (refresh)="refresh.emit()"
       ></app-landing-page-content>
 
-      <app-footer></app-footer>
+      <div class="shrink-0 sticky bottom-0 z-20">
+        <app-footer></app-footer>
+      </div>
     </main>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- The birthday list lost its vertical scrollbar on small windows and the footer was not visible, so the paginator and footer need to remain accessible while the list scrolls.

### Description
- Adjusted the landing page shell to constrain flex heights by adding `min-h-0`, `overflow-hidden`, `gap-2` to the main container in `front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html` and wrapped the footer in a sticky bottom container (`sticky bottom-0 z-20`).
- Updated landing content layout in `front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html` to use `min-h-0`/`flex-1`/`overflow-y-auto` and changed the birthday table host to `class="block h-full"` so the inner table can fill and scroll.
- Made the birthday table container and rows scrollable in `front-end/src/app/components/birthday-table/birthday-table.component.html` by setting the outer wrapper to `class="flex h-full min-h-0 flex-col overflow-hidden"` and the inner rows area to `class="min-h-0 flex-1 overflow-y-auto"`, and made the paginator sticky with `class="sticky bottom-0 z-10 border-t bg-white"` so it stays visible while scrolling.

### Testing
- Ran `npm run build`, which failed in this environment due to Google Fonts inlining returning HTTP 403 (environmental issue), so build artifacts could not be validated by the bundler.
- Ran `npm run start -- --host 0.0.0.0 --port 4200` and verified the dev server served and the layout changes rendered as expected.
- Executed a Playwright script to capture a screenshot of the updated layout and produced `artifacts/.../birthday-layout-fix.png` to visually confirm the scrollbar, sticky paginator, and pinned footer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5cf4c63c8332952aeefdf32a2e81)