### PR TITLE
Add refresh-token inactivity timeout and rotation

### DIFF
--- a/back-end/time2wish_api/src/main/java/com/time2wish/time2wish_api/controller/UserController.java
+++ b/back-end/time2wish_api/src/main/java/com/time2wish/time2wish_api/controller/UserController.java
@@ -10,7 +10,6 @@ import io.jsonwebtoken.JwtException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -89,11 +88,7 @@ public class UserController {
             String refreshToken = tokenProvider.generateRefreshToken(user);
 
             // 2. CRÉATION DU COOKIE (REFRESH TOKEN)
-            String cookieValue = String.format("refreshToken=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=Lax",
-                    refreshToken,
-                    tokenProvider.getRefreshTokenExpirationInSeconds()); // Utiliser la durée longue
-
-            response.addHeader("Set-Cookie", cookieValue);
+            response.addHeader("Set-Cookie", buildRefreshTokenCookieHeader(refreshToken, tokenProvider.getRefreshTokenExpirationInSeconds()));
 
             // 3. CRÉATION DU DTO DE RÉPONSE
             List<BirthdayDTO> birthdayDTOs = user.getBirthdays().stream()
@@ -120,7 +115,7 @@ public class UserController {
      * POST /api/refresh
      */
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request) {
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = null;
 
@@ -153,14 +148,23 @@ public class UserController {
             // 3. Récupérer l'ID utilisateur à partir des claims
             String userId = claims.getSubject();
 
-            // 4. Récupérer l'utilisateur et générer un nouveau token...
+            if (tokenProvider.isRefreshTokenInactive(claims)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Collections.singletonMap("message", "Session expirée après inactivité. Veuillez vous reconnecter."));
+            }
+
+            // 4. Récupérer l'utilisateur et régénérer la paire de tokens
             Optional<User> userOptional = userService.getUser(Long.valueOf(userId));
 
             if (userOptional.isPresent()) {
                 User user = userOptional.get();
 
-                // Générer un NOUVEL Access Token
+                // Générer un NOUVEL Access Token + ROTATION DU REFRESH TOKEN
                 String newAccessToken = tokenProvider.generateAccessToken(user);
+                String newRefreshToken = tokenProvider.generateRefreshToken(user);
+
+                // Mettre à jour le cookie HttpOnly avec le nouveau refresh token
+                response.addHeader("Set-Cookie", buildRefreshTokenCookieHeader(newRefreshToken, tokenProvider.getRefreshTokenExpirationInSeconds()));
 
                 // Retourner le nouvel Access Token dans le corps
                 return ResponseEntity.ok(Collections.singletonMap("accessToken", newAccessToken));
@@ -346,6 +350,12 @@ public class UserController {
         SecurityContextHolder.clearContext();
 
         return ResponseEntity.ok(new MessageResponse("Déconnexion réussie"));
+    }
+
+    private String buildRefreshTokenCookieHeader(String refreshToken, int maxAgeInSeconds) {
+        return String.format("refreshToken=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=Lax",
+                refreshToken,
+                maxAgeInSeconds);
     }
 
     // 1. Demander la réinitialisation (envoi de l'email via le service)

--- a/back-end/time2wish_api/src/main/java/com/time2wish/time2wish_api/security/JwtTokenProvider.java
+++ b/back-end/time2wish_api/src/main/java/com/time2wish/time2wish_api/security/JwtTokenProvider.java
@@ -31,6 +31,9 @@ public class JwtTokenProvider {
     @Value("${app.refreshTokenExpirationInMs}")
     private int refreshTokenExpirationInMs; // Pour le Token de rafraîchissement
 
+    @Value("${app.refreshTokenInactivityTimeoutInMs:180000}")
+    private int refreshTokenInactivityTimeoutInMs; // 3 minutes par défaut
+
     // 3. Clé JWT interne (sécurisée)
     private SecretKey key;
 
@@ -85,6 +88,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setSubject(String.valueOf(user.getId()))
                 .claim("tokenType", "REFRESH") // Ajout du type de token
+                .claim("lastActivityAt", now.getTime())
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(key, SignatureAlgorithm.HS512)
@@ -94,6 +98,16 @@ public class JwtTokenProvider {
     // Ajout d'une méthode pour l'expiration du cookie (en secondes)
     public int getRefreshTokenExpirationInSeconds() {
         return refreshTokenExpirationInMs / 1000;
+    }
+
+    public boolean isRefreshTokenInactive(Claims claims) {
+        Long lastActivityAt = claims.get("lastActivityAt", Long.class);
+        if (lastActivityAt == null) {
+            return true;
+        }
+
+        long inactiveForMs = System.currentTimeMillis() - lastActivityAt;
+        return inactiveForMs > refreshTokenInactivityTimeoutInMs;
     }
 
     /**

--- a/back-end/time2wish_api/src/main/resources/application.properties
+++ b/back-end/time2wish_api/src/main/resources/application.properties
@@ -10,22 +10,25 @@ logging.level.org.springframework.boot.web.embedded.tomcat=INFO
 spring.h2.console.enabled=true
 
 # JWT Configuration
-# La valeur ci-dessous est un exemple de clé forte de 64 caractères (512 bits), encodée en Base64.
-# GÉNÉREZ VOTRE PROPRE CLÉ SECRÈTE (min 32 caractères aléatoires, puis encodez-la en Base64).
+# Inactivit maximale (3 minutes) avant forcer la reconnexion
+app.refreshTokenInactivityTimeoutInMs=180000
+
+# La valeur ci-dessous est un exemple de clÃ© forte de 64 caractÃ¨res (512 bits), encodÃ©e en Base64.
+# GÃ‰NÃ‰REZ VOTRE PROPRE CLÃ‰ SECRÃˆTE (min 32 caractÃ¨res alÃ©atoires, puis encodez-la en Base64).
 app.jwtSecret=NDA3ZjA0NTRjMjcwYmFhZjVlZTI5OGE4NTEyN2I2N2Y0YTJkMWJkMjM4NzlmYzA5NDUwNDQ3ZWIzZTYxYzE4Nw==
 # cle valide pour 24h
 app.jwtExpirationInMs=86400000
 
-# Access Token (Durée courte : 15 minutes)
+# Access Token (DurÃ©e courte : 15 minutes)
 app.accessTokenExpirationInMs=900000 
 
-# Refresh Token (Durée longue : 7 jours)
+# Refresh Token (DurÃ©e longue : 7 jours)
 app.refreshTokenExpirationInMs=604800000
 
 # Affiche au moins le niveau INFO pour tout Spring Boot
 logging.level.org.springframework=INFO
 
-# Active le niveau DEBUG pour le package de sécurité (pour voir le suivi détaillé)
+# Active le niveau DEBUG pour le package de sÃ©curitÃ© (pour voir le suivi dÃ©taillÃ©)
 logging.level.com.time2wish.time2wish_api.security=DEBUG
 
 spring.mail.host=sandbox.smtp.mailtrap.io


### PR DESCRIPTION
### Motivation
- Résoudre le comportement de déconnexion après inactivité en gérant l’invalidité des refresh tokens côté backend et en forçant la reconnexion si l’utilisateur reste inactif au-delà d’un délai configuré.
- Réduire la fenêtre d’abus en faisant la rotation du refresh token à chaque opération de rafraîchissement et en liant le refresh token à l’activité récente.

### Description
- Ajout d’une propriété configurable `app.refreshTokenInactivityTimeoutInMs` (valeur par défaut `180000`) dans `application.properties` pour définir le délai d’inactivité maximal avant expiration du refresh token.
- Dans `JwtTokenProvider` : ajout du claim `lastActivityAt` dans le refresh token et nouvelle méthode `isRefreshTokenInactive(Claims)` qui vérifie l’inactivité par rapport au timeout configuré.
- Dans `UserController` : modification de l’endpoint `POST /api/refresh` pour accepter `HttpServletResponse`, vérifier l’inactivité via `isRefreshTokenInactive(...)`, refuser la session inactive, et effectuer la rotation du refresh token (générer un nouveau refresh token et mettre à jour le cookie HttpOnly); extraction d’un helper `buildRefreshTokenCookieHeader(...)` réutilisé depuis le `login` et `refresh`.
- Ajustements mineurs : conservation des protections HttpOnly/SameSite pour le cookie et maintien de la logique de logout qui expire le cookie côté client.

### Testing
- Tentative d’exécution `./mvnw test -q` échouée en local à cause d’une erreur de permission sur `mvnw` (Permission denied).
- Tentative d’exécution `mvn test -q` échouée en local en raison d’un échec de résolution des dépendances Maven (accès au dépôt central retournant HTTP 403), empêchant l’exécution des tests unitaires.
- Aucun test automatisé n’a pu être exécuté et validé dans cet environnement en raison des erreurs d’environnement réseau/permissions ci‑dessus.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86cfd113c8332bf1cc839413b64ea)