### PR TITLE
Rewrite README, add frontend skills docs, and add CI workflows for frontend/backend/docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ A full-stack web application to manage birthdays, automate reminders, and centra
 
 ---
 
+### time2wish-v1.0.1 - dark mode
+<img width="1886" height="914" alt="image" src="https://github.com/user-attachments/assets/825bfb27-e417-4bab-86b1-82bec1cf9797" />
+
+
+
+### time2wish-v1.0.0
+<img width="2545" height="1302" alt="image" src="https://github.com/user-attachments/assets/1ba18752-b903-47e2-8fdb-068c460067b8" />
+
+### Light mode
+<img width="2549" height="1306" alt="image" src="https://github.com/user-attachments/assets/d868085d-0bea-4f47-bb93-a59af19b979d" />
+
+### Dark mode
+<img width="2554" height="1299" alt="image" src="https://github.com/user-attachments/assets/6d5d84fb-4eb9-4c95-a530-6383a138bf41" />
+
 ## 1) Project Vision
 
 **Time2Wish** helps users never miss important birthdays by combining:
@@ -204,6 +218,48 @@ cd back-end/time2wish_api
 
 ---
 
-## 10) License
+---
 
-Internal project under active development. Add an explicit license before public release.
+## 🛠️ Technical Stack
+
+| Layer         | Technologies                                | Status          |
+|---------------|---------------------------------------------|-----------------|
+| **Frontend**  | Angular 19+ with TypeScript                 | 🚧 In Progress  |
+| **Backend**   | Spring Boot (2.3.2.RELEASE) | 🚧 In Progress  |
+| **Database**  | Firestore / MongoDB / PostgreSQL            | 🟡 To be decided |
+| **Notifications** | Web Push API / Firebase Cloud Messaging | 🟡 To be decided |
+| **APIs**      | Twilio / SendGrid or similar messaging APIs | 🟡 To be decided |
+
+---
+
+---
+
+## 🚀 Project Status
+
+The project is currently in early-stage development. Core architecture and features are being built.
+
+> 🔧 Contributions and ideas are welcome!
+
+---
+
+## 📌 Future Enhancements (Roadmap)
+
+- ✅ PWA support for mobile use
+- 🧠 AI-powered birthday message generator
+- 📅 Calendar integrations (Google, Outlook)
+- 🎁 Group gift reminders and planning (to be decided)
+- 🗂️ Birthday history and wish archive
+
+---
+
+## 🙌 Contribution
+
+Want to contribute or support the project?
+
+- 🐛 [Open an issue](#) to report bugs or suggest features.
+- 🚀 Submit a pull request.
+- 💬 Share feedback and ideas.
+
+## Usefull link
+- Login and logout workflow explain: https://hasura.io/blog/best-practices-of-using-jwt-with-graphql
+---

--- a/README.md
+++ b/README.md
@@ -1,133 +1,209 @@
-# 🎉 Time2Wish – Birthday Reminder Application
+# Time2Wish
 
-> A smart and stylish way to never forget the special moments of your loved ones.
-
-### time2wish-v1.0.1 - dark mode
-<img width="1886" height="914" alt="image" src="https://github.com/user-attachments/assets/825bfb27-e417-4bab-86b1-82bec1cf9797" />
-
-
-
-### time2wish-v1.0.0
-<img width="2545" height="1302" alt="image" src="https://github.com/user-attachments/assets/1ba18752-b903-47e2-8fdb-068c460067b8" />
-
-### Light mode
-<img width="2549" height="1306" alt="image" src="https://github.com/user-attachments/assets/d868085d-0bea-4f47-bb93-a59af19b979d" />
-
-### Dark mode
-<img width="2554" height="1299" alt="image" src="https://github.com/user-attachments/assets/6d5d84fb-4eb9-4c95-a530-6383a138bf41" />
-
-
-
+A full-stack web application to manage birthdays, automate reminders, and centralize useful contact information (preferences, notes, and more).
 
 ---
 
-## 🧭 Overview
+## 1) Project Vision
 
-**Time2Wish** is a modern web application built with Angular that helps users remember birthdays, organize meaningful wishes, and celebrate those they care about. It’s more than just a reminder app, it’s your personal assistant for creating unforgettable moments.
+**Time2Wish** helps users never miss important birthdays by combining:
 
----
-
-## 👥 Target Audience
-
-Time2Wish is designed for anyone who wants to:
-
-- Stay organized and never miss a birthday.
-- Make birthdays more memorable with personalized messages and gift ideas.
-- Share joy and celebration with friends, family, and colleagues.
+- a modern frontend experience (Angular),
+- a secure backend API (Spring Boot + JWT),
+- a relational data layer (JPA, H2 in local runtime),
+- notification and password-reset email flows.
 
 ---
 
-## ✨ Key Features
+## 2) Core Features
 
-### 🔐 User Management
+### 2.1 Authentication & Security
+- User registration.
+- Login with **Access Token** and **Refresh Token** generation.
+- Refresh token stored in an HTTP-only cookie.
+- Protected frontend routes via Angular Auth Guard.
 
-- Email-based sign-up and login.
-- User profile management:
-  - Photo
-  - Name
-  - Notification preferences
-- Secure authentication and user sessions.
+### 2.2 Birthday Management
+- Create, read, update, and delete birthdays.
+- Birthday table/list views.
+- Birthday details pages.
 
-### 🎂 Birthday Management
+### 2.3 User Profile Management
+- View and update profile data.
+- Preferences support (language, theme, notifications).
 
-- Add and manage contacts with:
-  - Photo, name, date of birth
-  - Relationship type (friend, family, colleague, etc.)
-  - Personal notes (gift ideas, preferences)
-- Categorize contacts into custom groups.
-- Search, filter, and sort contact list.
-
-### ⏰ Notifications & Reminders
-
-- Custom reminder options (1 day, 1 week, or custom settings).
-- Multiple notification channels (planned).
-- Smart alerts for upcoming birthdays.
-
-### 🎁 Gift & Wish Suggestions
-
-- Personalized gift and message ideas based on contact preferences.
-- Auto-generated birthday messages with editable templates.
-- Quick-send message feature.
-
-### 🖥️ User Interface
-
-- Clean dashboard showing upcoming birthdays.
-- Multilingual support (i18n ready).
-- Accessible UI.
-
-### ➕ Additional Features
-
-- Import contacts from address books (Google, Outlook – planned).
-- Share reminders with family or friends.
-- Export to calendar formats (e.g. `.ics` file).
-- Birthday archive and wish history.
+### 2.4 User Experience
+- Responsive interface.
+- Light and dark themes.
+- Internationalization (FR/EN/DE with Transloco).
+- Public and private screens (landing, login, dashboard, etc.).
 
 ---
 
-## 🛠️ Technical Stack
+## 3) Technical Stack
 
-| Layer         | Technologies                                | Status          |
-|---------------|---------------------------------------------|-----------------|
-| **Frontend**  | Angular 19+ with TypeScript                 | 🚧 In Progress  |
-| **Backend**   | Spring Boot (2.3.2.RELEASE) | 🚧 In Progress  |
-| **Database**  | Firestore / MongoDB / PostgreSQL            | 🟡 To be decided |
-| **Notifications** | Web Push API / Firebase Cloud Messaging | 🟡 To be decided |
-| **APIs**      | Twilio / SendGrid or similar messaging APIs | 🟡 To be decided |
+### Frontend
+- Angular 19
+- TypeScript
+- Angular Material + CDK
+- Tailwind CSS v4
+- Transloco (i18n)
+- Chart.js / ng2-charts
 
----
+### Backend
+- Java 8
+- Spring Boot 2.3.2.RELEASE
+- Spring Security
+- Spring Data JPA
+- JWT (jjwt)
+- Spring Mail
 
-## 🚀 Project Status
-
-The project is currently in early-stage development. Core architecture and features are being built.
-
-> 🔧 Contributions and ideas are welcome!
-
----
-
-## 📌 Future Enhancements (Roadmap)
-
-- ✅ PWA support for mobile use
-- 🧠 AI-powered birthday message generator
-- 📅 Calendar integrations (Google, Outlook)
-- 🎁 Group gift reminders and planning (to be decided)
-- 🗂️ Birthday history and wish archive
+### Data & Runtime
+- H2 (local runtime)
+- Docker / Docker Compose (dev and prod-like)
 
 ---
 
-## 🙌 Contribution
+## 4) High-Level Architecture
 
-Want to contribute or support the project?
+```text
+[Browser User]
+      |
+      v
+[Angular Frontend (port 4200 in dev / 80 in container)]
+      |
+      | HTTP (Bearer access token)
+      v
+[Spring Boot API (port 9000)]
+      |
+      +--> [JWT Service + Security Filter]
+      +--> [Business Services: User/Birthday/Email]
+      +--> [JPA Repositories]
+      v
+    [H2 Database]
+```
 
-- 🐛 [Open an issue](#) to report bugs or suggest features.
-- 🚀 Submit a pull request.
-- 💬 Share feedback and ideas.
+### 4.1 Frontend Architecture (simplified)
 
-## Usefull link
-- Login and logout workflow explain: https://hasura.io/blog/best-practices-of-using-jwt-with-graphql
+```text
+src/app
+├── core
+│   ├── guard (auth)
+│   └── services (auth, birthday, interceptor)
+├── pages (login, register, dashboard, profile, etc.)
+├── components (navbar, cards, forms, footer, etc.)
+├── shared/services (theme, notifications, dialog, confetti)
+└── models
+```
+
+### 4.2 Backend Architecture (simplified)
+
+```text
+com.time2wish.time2wish_api
+├── controller (UserController, BirthdayController)
+├── service (UserService, BirthdayService, EmailService)
+├── repository (UserRepository, BirthdayRepository)
+├── security (JwtTokenProvider, JwtAuthenticationFilter)
+├── dto
+└── model (User, Birthday)
+```
+
 ---
 
-## 📄 License
+## 5) API Endpoints (Overview)
 
-_This project will be released under an open-source license (TBD)._
+### Authentication / Users
+- `POST /api/register`
+- `POST /api/login`
+- `POST /api/refresh`
+- `GET /api/users`
+- `GET /api/users/{id}`
+- `PUT /api/users/{id}`
+
+### Birthdays
+- `GET /birthdayTable`
+- `POST /birthdayTable`
+- `GET /birthday/{id}`
+- `PUT /birthday/{id}`
+- `DELETE /birthday/{id}`
 
 ---
+
+## 6) Run the Project
+
+### 6.1 Prerequisites
+- Node.js + npm
+- Java 8+
+- Maven
+- Docker (optional)
+
+### 6.2 Frontend (local)
+```bash
+cd front-end
+npm install
+npm run start
+```
+Available at `http://localhost:4200`.
+
+### 6.3 Backend (local)
+```bash
+cd back-end/time2wish_api
+./mvnw spring-boot:run
+```
+Available at `http://localhost:9000`.
+
+### 6.4 Docker Compose (prod-like)
+```bash
+docker compose up --build
+```
+- Frontend: `http://localhost:80`
+- Backend: `http://localhost:9000`
+
+### 6.5 Docker Compose (dev)
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+- Frontend: `http://localhost:4200`
+- Backend: `http://localhost:9000`
+
+---
+
+## 7) Quality & Testing
+
+### Frontend
+```bash
+cd front-end
+npm run lint
+npm run test
+npm run build
+```
+
+### Backend
+```bash
+cd back-end/time2wish_api
+./mvnw test
+```
+
+---
+
+## 8) Security & Secrets
+
+- JWT secrets and email credentials should be externalized with environment variables.
+- Avoid committing real secrets to version control.
+- Use isolated environment profiles (`dev`, `prod`) with secure config values.
+
+---
+
+## 9) Suggested Roadmap
+
+- Add a production-grade persistent database (PostgreSQL/MySQL).
+- Add a scheduler for automated reminders.
+- Expand CI/CD with deployment stages.
+- Improve observability (structured logs, metrics, tracing).
+- Add end-to-end frontend tests.
+
+---
+
+## 10) License
+
+Internal project under active development. Add an explicit license before public release.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,20 @@
+# Frontend Skills for Time2Wish
+
+This folder contains reusable **frontend skills** to accelerate development and improve consistency in the Time2Wish project.
+
+## Skill List
+
+1. `angular-architecture.md`
+2. `ui-ux-accessibility.md`
+3. `frontend-testing.md`
+4. `performance-optimization.md`
+5. `i18n-and-theming.md`
+
+## Goal
+
+Standardize frontend engineering practices to:
+- keep a clear architecture,
+- improve quality and accessibility,
+- ensure testability,
+- optimize performance,
+- support multilingual UI and theming.

--- a/skills/angular-architecture.md
+++ b/skills/angular-architecture.md
@@ -1,0 +1,16 @@
+# Skill: Angular Architecture
+
+## Goal
+Design a scalable and maintainable Angular application structure.
+
+## Guidelines
+- Separate concerns across `core`, `shared`, `features/pages`, and `models`.
+- Use lazy loading / `loadComponent` for pages.
+- Centralize HTTP calls inside domain services.
+- Keep guards, interceptors, and authentication logic under `core`.
+- Prefer standalone and decoupled components.
+
+## Checklist
+- [ ] One service per business domain.
+- [ ] No heavy business logic inside templates.
+- [ ] Explicit types/interfaces for all API responses.

--- a/skills/frontend-testing.md
+++ b/skills/frontend-testing.md
@@ -1,0 +1,22 @@
+# Skill: Frontend Testing
+
+## Goal
+Protect feature changes with focused unit tests.
+
+## Strategy
+- Test services (HTTP calls, mapping, business logic).
+- Test critical components (auth, forms, navigation).
+- Mock external dependencies.
+- Cover both success and failure scenarios.
+
+## Useful Commands
+```bash
+npm run test -- --watch=false --browsers=ChromeHeadless
+npm run lint
+npm run build
+```
+
+## Checklist
+- [ ] New services include tests.
+- [ ] Form components validate input and error states.
+- [ ] CI runs lint + tests + build.

--- a/skills/i18n-and-theming.md
+++ b/skills/i18n-and-theming.md
@@ -1,0 +1,15 @@
+# Skill: i18n & Theming
+
+## Goal
+Provide a consistent multilingual experience across light/dark themes.
+
+## Best Practices
+- Centralize translation keys in `public/assets/i18n`.
+- Avoid hardcoded UI strings in components.
+- Manage themes through a dedicated theme service.
+- Validate pages in FR/EN/DE.
+
+## Checklist
+- [ ] New UI strings are translated.
+- [ ] Language selection is persisted.
+- [ ] Theme changes apply globally without visual flicker.

--- a/skills/performance-optimization.md
+++ b/skills/performance-optimization.md
@@ -1,0 +1,16 @@
+# Skill: Frontend Performance Optimization
+
+## Goal
+Improve load times and runtime smoothness.
+
+## Best Practices
+- Use lazy loading for large pages.
+- Avoid expensive operations in templates.
+- Keep static assets and images optimized.
+- Remove unused dependencies.
+- Use `trackBy` for long rendered lists.
+
+## Checklist
+- [ ] Heavy pages are split into smaller parts.
+- [ ] Bundle size is monitored over time.
+- [ ] Images are compressed and optimized.

--- a/skills/ui-ux-accessibility.md
+++ b/skills/ui-ux-accessibility.md
@@ -1,0 +1,16 @@
+# Skill: UI/UX & Accessibility
+
+## Goal
+Build a clean, consistent, and accessible interface.
+
+## Best Practices
+- Respect visual hierarchy (headings, spacing, contrast).
+- Use explicit labels for form fields.
+- Add relevant ARIA attributes.
+- Ensure keyboard navigation works correctly.
+- Validate contrast in both light and dark themes.
+
+## Checklist
+- [ ] Critical flows are usable without a mouse.
+- [ ] Error messages are visible and understandable.
+- [ ] Important actions have clear states (hover/focus/disabled/loading).

--- a/worflow/backend-ci.yml
+++ b/worflow/backend-ci.yml
@@ -1,0 +1,35 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - 'back-end/**'
+      - 'worflow/backend-ci.yml'
+  pull_request:
+    paths:
+      - 'back-end/**'
+      - 'worflow/backend-ci.yml'
+
+jobs:
+  backend-quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: back-end/time2wish_api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+
+      - name: Run tests
+        run: ./mvnw test
+
+      - name: Package
+        run: ./mvnw -DskipTests package

--- a/worflow/docker-ci.yml
+++ b/worflow/docker-ci.yml
@@ -1,0 +1,30 @@
+name: Docker Compose Validation
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'docker-compose.yml'
+      - 'docker-compose.dev.yml'
+      - 'front-end/Dockerfile'
+      - 'back-end/time2wish_api/Dockerfile'
+      - 'worflow/docker-ci.yml'
+
+jobs:
+  validate-docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build frontend image
+        run: docker build -t time2wish-frontend-test ./front-end
+
+      - name: Build backend image
+        run: docker build -t time2wish-backend-test ./back-end/time2wish_api
+
+      - name: Validate compose files
+        run: |
+          docker compose -f docker-compose.yml config
+          docker compose -f docker-compose.dev.yml config

--- a/worflow/frontend-ci.yml
+++ b/worflow/frontend-ci.yml
@@ -1,0 +1,41 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - 'front-end/**'
+      - 'worflow/frontend-ci.yml'
+  pull_request:
+    paths:
+      - 'front-end/**'
+      - 'worflow/frontend-ci.yml'
+
+jobs:
+  frontend-quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front-end
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: front-end/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests (headless)
+        run: npm run test -- --watch=false --browsers=ChromeHeadless
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
### Motivation

- Provide a comprehensive project overview, architecture diagrams, and clear run instructions to make onboarding easier. 
- Standardize frontend practices by introducing reusable "skills" guidance for architecture, testing, i18n/theming, performance, and accessibility. 
- Add automated CI checks and Docker validation to improve quality gates for frontend and backend changes. 

### Description

- Rewrote `README.md` into a structured document with project vision, core features, technical stack, architecture diagrams, run instructions, and security notes. 
- Added a new `skills/` folder with five guidance files: `angular-architecture.md`, `frontend-testing.md`, `i18n-and-theming.md`, `performance-optimization.md`, and `ui-ux-accessibility.md`. 
- Added CI workflow files under `worflow/`: `frontend-ci.yml`, `backend-ci.yml`, and `docker-ci.yml` that configure GitHub Actions to run linting, unit tests, builds, Maven tests, and Docker image/compose validation. 
- Included local run commands and sample CI commands in the docs, such as `npm run start`, `./mvnw spring-boot:run`, `npm run test`, and `./mvnw test` for reproducibility. 

### Testing

- No automated tests were executed as part of this change; this PR introduces CI workflows that will run on future pushes and pull requests. 
- The added CI configs are set to run `npm run lint` and `npm run test -- --watch=false --browsers=ChromeHeadless` for the frontend, `./mvnw test` for the backend, and `docker build` plus `docker compose ... config` for Docker validation. 
- CI steps are configured to run on changes under `front-end/**`, `back-end/**`, and the workflow files themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0059e744833296ea88e6fee45341)