### PR TITLE
feat(frontend): modernize dashboard UI with cleaner responsive layout

### DIFF
--- a/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
+++ b/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
@@ -1,16 +1,16 @@
 <aside
-  class="sticky top-0 left-0 flex h-screen flex-col border-r border-gray-200/70 bg-white/90 px-2 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.06)] backdrop-blur transition-all duration-300 ease-in-out"
-  [style.width]="expanded() ? '280px' : '84px'"
+  class="sticky top-0 left-0 flex h-screen flex-col border-r border-gray-200/70 bg-white/95 px-2 py-4 shadow-[0_8px_24px_rgba(15,23,42,0.08)] transition-all duration-300 ease-in-out"
+  [style.width]="expanded() ? '260px' : '72px'"
 >
   <div class="flex h-full flex-col gap-2" *transloco="let t">
     <button
       type="button"
-      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
+      class="dashboard-nav-btn"
       (click)="toggleSidebar()"
       [matTooltip]="!expanded() ? t('sidebar.menu') : ''"
       matTooltipPosition="right"
     >
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80">
+      <span class="dashboard-nav-icon">
         <mat-icon class="text-gray-700">menu_open</mat-icon>
       </span>
       @if (expanded()) {
@@ -18,60 +18,36 @@
       }
     </button>
 
-    <button
-      type="button"
-      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
-      (click)="onSetting()"
-      [matTooltip]="!expanded() ? t('sidebar.settings') : ''"
-      matTooltipPosition="right"
-    >
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">settings</mat-icon></span>
+    <button type="button" class="dashboard-nav-btn" (click)="onSetting()" [matTooltip]="!expanded() ? t('sidebar.settings') : ''" matTooltipPosition="right">
+      <span class="dashboard-nav-icon"><mat-icon class="text-gray-700">settings</mat-icon></span>
       @if (expanded()) {
         <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.settings') }}</span>
       }
     </button>
 
-    <button
-      type="button"
-      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
-      (click)="onAddBirthday()"
-      [matTooltip]="!expanded() ? t('sidebar.add_user') : ''"
-      matTooltipPosition="right"
-    >
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">person_add</mat-icon></span>
+    <button type="button" class="dashboard-nav-btn" (click)="onAddBirthday()" [matTooltip]="!expanded() ? t('sidebar.add_user') : ''" matTooltipPosition="right">
+      <span class="dashboard-nav-icon"><mat-icon class="text-gray-700">person_add</mat-icon></span>
       @if (expanded()) {
         <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.add_user') }}</span>
       }
     </button>
 
-    <button
-      type="button"
-      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
-      (click)="onStatistics()"
-      [matTooltip]="!expanded() ? t('sidebar.statistics') : ''"
-      matTooltipPosition="right"
-    >
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">bar_chart</mat-icon></span>
+    <button type="button" class="dashboard-nav-btn" (click)="onStatistics()" [matTooltip]="!expanded() ? t('sidebar.statistics') : ''" matTooltipPosition="right">
+      <span class="dashboard-nav-icon"><mat-icon class="text-gray-700">bar_chart</mat-icon></span>
       @if (expanded()) {
         <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.statistics') }}</span>
       }
     </button>
 
-    <button
-      type="button"
-      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
-      (click)="onPricing()"
-      [matTooltip]="!expanded() ? t('sidebar.pricing') : ''"
-      matTooltipPosition="right"
-    >
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">workspace_premium</mat-icon></span>
+    <button type="button" class="dashboard-nav-btn" (click)="onPricing()" [matTooltip]="!expanded() ? t('sidebar.pricing') : ''" matTooltipPosition="right">
+      <span class="dashboard-nav-icon"><mat-icon class="text-gray-700">workspace_premium</mat-icon></span>
       @if (expanded()) {
         <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.pricing') }}</span>
       }
     </button>
 
-    <div class="mt-auto rounded-xl border border-gray-200/70 bg-gray-200/40 p-3 text-center">
-      <img src="time2wish-logo.png" alt="Logo" class="mx-auto h-12 w-12 object-contain" [class.h-10]="!expanded()" [class.w-10]="!expanded()" />
+    <div class="mt-auto rounded-xl border border-gray-200/80 bg-gray-200/50 p-3 text-center">
+      <img src="time2wish-logo.png" alt="Logo" class="mx-auto h-10 w-10 object-contain md:h-12 md:w-12" />
       @if (expanded()) {
         <p class="mt-2 text-sm font-semibold text-gray-800">{{ t('sidebar.app_name') }}</p>
         <p class="text-xs text-gray-500">{{ t('sidebar.version') }}: {{ version() }}</p>

--- a/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
+++ b/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
@@ -1,116 +1,80 @@
 <aside
-  class="sticky top-0 left-0 h-screen bg-white flex flex-col items-center transition-all duration-100 ease-in-out shadow-sm border-r border-gray-100"
-  [class.w-16]="!expanded()"
-  [class.px-4]="expanded()"
-  [style.width]="expanded() ? '280px' : '5rem'"
+  class="sticky top-0 left-0 flex h-screen flex-col border-r border-gray-200/70 bg-white/90 px-2 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.06)] backdrop-blur transition-all duration-300 ease-in-out"
+  [style.width]="expanded() ? '280px' : '84px'"
 >
-  <div class="flex flex-col mt-10 w-full gap-2" *transloco="let t">
-    
+  <div class="flex h-full flex-col gap-2" *transloco="let t">
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
       (click)="toggleSidebar()"
       [matTooltip]="!expanded() ? t('sidebar.menu') : ''"
       matTooltipPosition="right"
     >
-      <div class="w-20 flex shrink-0 justify-center py-2">
-        <mat-icon class="text-gray-600">menu</mat-icon>
-      </div>
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80">
+        <mat-icon class="text-gray-700">menu_open</mat-icon>
+      </span>
       @if (expanded()) {
-        <span class="whitespace-nowrap font-medium text-gray-700">
-          {{ t('sidebar.menu') }}
-        </span>
+        <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.menu') }}</span>
       }
     </button>
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
       (click)="onSetting()"
       [matTooltip]="!expanded() ? t('sidebar.settings') : ''"
       matTooltipPosition="right"
     >
-      <div class="w-20 flex shrink-0 justify-center py-2">
-        <mat-icon class="text-gray-600">settings</mat-icon>
-      </div>
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">settings</mat-icon></span>
       @if (expanded()) {
-        <span class="whitespace-nowrap font-medium text-gray-700">
-          {{ t('sidebar.settings') }}
-        </span>
+        <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.settings') }}</span>
       }
     </button>
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
       (click)="onAddBirthday()"
       [matTooltip]="!expanded() ? t('sidebar.add_user') : ''"
       matTooltipPosition="right"
     >
-      <div class="w-20 flex shrink-0 justify-center py-2">
-        <mat-icon class="text-gray-600">person_add</mat-icon>
-      </div>
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">person_add</mat-icon></span>
       @if (expanded()) {
-        <span class="whitespace-nowrap font-medium text-gray-700">
-          {{ t('sidebar.add_user') }}
-        </span>
+        <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.add_user') }}</span>
       }
     </button>
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
       (click)="onStatistics()"
       [matTooltip]="!expanded() ? t('sidebar.statistics') : ''"
       matTooltipPosition="right"
     >
-      <div class="w-20 flex shrink-0 justify-center py-2">
-        <mat-icon class="text-gray-600">bar_chart</mat-icon>
-      </div>
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">bar_chart</mat-icon></span>
       @if (expanded()) {
-        <span class="whitespace-nowrap font-medium text-gray-700">
-          {{ t('sidebar.statistics') }}
-        </span>
+        <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.statistics') }}</span>
       }
     </button>
-    
+
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="group flex w-full items-center rounded-xl border border-transparent px-2 py-2 text-left transition-all hover:border-gray-200 hover:bg-gray-200/70"
       (click)="onPricing()"
       [matTooltip]="!expanded() ? t('sidebar.pricing') : ''"
       matTooltipPosition="right"
     >
-      <div class="w-20 flex shrink-0 justify-center py-2">
-        <mat-icon class="text-gray-600">monetization_on</mat-icon>
-      </div>
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-200/80"><mat-icon class="text-gray-700">workspace_premium</mat-icon></span>
       @if (expanded()) {
-        <span class="whitespace-nowrap font-medium text-gray-700">
-          {{ t('sidebar.pricing') }}
-        </span>
+        <span class="ml-3 font-medium text-gray-700">{{ t('sidebar.pricing') }}</span>
       }
     </button>
-  </div>
 
-  <div class="w-full p-4 mt-auto">
-    <div class="flex flex-col items-center" *transloco="let t">
-      <div class="flex items-center justify-center gap-2">
-        <img
-          src="time2wish-logo.png"
-          alt="Logo"
-          class="h-16 w-16 object-contain transition-transform duration-300"
-          [class.hidden]="expanded()"
-        />
-        @if (expanded()) {
-          <span class="text-lg font-semibold whitespace-nowrap transition-all duration-300">
-            {{ t('sidebar.app_name') }}
-          </span>
-        }
-      </div>
+    <div class="mt-auto rounded-xl border border-gray-200/70 bg-gray-200/40 p-3 text-center">
+      <img src="time2wish-logo.png" alt="Logo" class="mx-auto h-12 w-12 object-contain" [class.h-10]="!expanded()" [class.w-10]="!expanded()" />
       @if (expanded()) {
-        <div class="text-xs text-gray-500 whitespace-nowrap transition-all duration-300 mt-1">
-          {{ t('sidebar.version') }} : {{ version() }}
-        </div>
+        <p class="mt-2 text-sm font-semibold text-gray-800">{{ t('sidebar.app_name') }}</p>
+        <p class="text-xs text-gray-500">{{ t('sidebar.version') }}: {{ version() }}</p>
       }
     </div>
   </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -7,17 +7,17 @@
   } @else {
     <div class="flex min-h-0 flex-1 flex-col">
       @if (viewMode === 'table') {
-        <div class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-gray-200/70 bg-white/80 px-4 py-3 backdrop-blur">
+        <div class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-gray-200/70 bg-white/90 px-4 py-3">
           <div>
             <h2 class="text-base font-semibold text-gray-900">{{ activeButton === 'coming' ? t('anniversary.coming') : t('anniversary.passed') }}</h2>
             <p class="text-xs text-gray-500">{{ filteredBirthdays.length }} records</p>
           </div>
           <div class="flex gap-2">
-            <button mat-stroked-button class="!rounded-lg">
+            <button mat-stroked-button class="dashboard-action-btn">
               <mat-icon>file_upload</mat-icon>
               {{ t('actions.import') }}
             </button>
-            <button mat-stroked-button class="!rounded-lg">
+            <button mat-stroked-button class="dashboard-action-btn">
               <mat-icon>file_download</mat-icon>
               {{ t('actions.export') }}
             </button>
@@ -44,7 +44,7 @@
           }
         } @else {
           <div class="flex h-full flex-col items-center justify-center px-6 text-center text-gray-500">
-            <div class="mb-3 rounded-full bg-gray-200 p-4">
+            <div class="mb-3 rounded-full border border-gray-200 bg-gray-200 p-4">
               <mat-icon class="!h-8 !w-8 !text-3xl">event_busy</mat-icon>
             </div>
             <p class="text-sm">{{ t(activeButton === 'coming' ? 'anniversary.empty_coming' : 'anniversary.empty_passed') }}</p>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -1,47 +1,53 @@
-<div class="mt-4 flex-1 bg-white rounded-lg shadow-lg overflow-hidden flex flex-col h-full" *transloco="let t">
-  
+<div class="flex h-full flex-1 flex-col" *transloco="let t">
   @if (isLoading) {
-    <div class="flex flex-col flex-1 items-center justify-center">
-      <mat-spinner diameter="50" color="primary"></mat-spinner>
-      <p class="text-gray-600 text-sm mt-2">{{ t('anniversary.loading') }}</p>
+    <div class="flex flex-1 flex-col items-center justify-center gap-3">
+      <mat-spinner diameter="48" color="primary"></mat-spinner>
+      <p class="text-sm text-gray-500">{{ t('anniversary.loading') }}</p>
     </div>
   } @else {
-    <div class="flex flex-col h-full min-h-0">
-      
+    <div class="flex min-h-0 flex-1 flex-col">
       @if (viewMode === 'table') {
-        <div class="p-4 border-b border-gray-200 shrink-0 bg-white z-20">
+        <div class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-gray-200/70 bg-white/80 px-4 py-3 backdrop-blur">
+          <div>
+            <h2 class="text-base font-semibold text-gray-900">{{ activeButton === 'coming' ? t('anniversary.coming') : t('anniversary.passed') }}</h2>
+            <p class="text-xs text-gray-500">{{ filteredBirthdays.length }} records</p>
+          </div>
           <div class="flex gap-2">
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-md">
-              <mat-icon>file_upload</mat-icon> {{ t('actions.import') }}
+            <button mat-stroked-button class="!rounded-lg">
+              <mat-icon>file_upload</mat-icon>
+              {{ t('actions.import') }}
             </button>
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-md">
-              <mat-icon>file_download</mat-icon> {{ t('actions.export') }}
+            <button mat-stroked-button class="!rounded-lg">
+              <mat-icon>file_download</mat-icon>
+              {{ t('actions.export') }}
             </button>
           </div>
         </div>
       }
 
-      <div class="flex-1 min-h-0 overflow-hidden relative">
+      <div class="relative min-h-0 flex-1 overflow-hidden">
         @if (hasBirthdays) {
           @if (viewMode === 'table') {
-            <app-birthday-table 
-              class="block h-full" 
-              [birthdays]="filteredBirthdays" 
-              (edit)="birthdayEdit.emit()" 
-              (delete)="birthdayDelete.emit($event)" 
-              (refresh)="refresh.emit()">
-            </app-birthday-table>
+            <app-birthday-table
+              class="block h-full"
+              [birthdays]="filteredBirthdays"
+              (edit)="birthdayEdit.emit()"
+              (delete)="birthdayDelete.emit($event)"
+              (refresh)="refresh.emit()"
+            ></app-birthday-table>
           } @else {
-            <div class="h-full overflow-y-auto p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 custom-scrollbar">
+            <div class="custom-scrollbar grid h-full grid-cols-1 gap-4 overflow-y-auto p-4 md:grid-cols-2 2xl:grid-cols-3">
               @for (item of filteredBirthdays; track item.id) {
-                <app-birthday-card [item]="item" ...></app-birthday-card>
+                <app-birthday-card [item]="item"></app-birthday-card>
               }
             </div>
           }
         } @else {
-          <div class="p-8 text-center text-gray-500 flex flex-col items-center justify-center h-full">
-            <mat-icon class="text-4xl mb-2">event_busy</mat-icon>
-            <p>{{ t('anniversary.empty_coming') }}</p>
+          <div class="flex h-full flex-col items-center justify-center px-6 text-center text-gray-500">
+            <div class="mb-3 rounded-full bg-gray-200 p-4">
+              <mat-icon class="!h-8 !w-8 !text-3xl">event_busy</mat-icon>
+            </div>
+            <p class="text-sm">{{ t(activeButton === 'coming' ? 'anniversary.empty_coming' : 'anniversary.empty_passed') }}</p>
           </div>
         }
       </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
@@ -1,127 +1,126 @@
-<div class="!rounded-lg !shadow-md !p-4 bg-white mt-4" *transloco="let t">
-  <div class="flex items-center justify-between w-full">
-    <div class="flex items-center">
-      <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-12 md:h-16 ml-2 md:ml-7" />
-    </div>
+<div class="space-y-4" *transloco="let t">
+  <section class="rounded-2xl border border-gray-200/70 bg-white p-3 shadow-[0_10px_28px_rgba(15,23,42,0.05)] md:p-4">
+    <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+      <div class="flex items-center gap-3">
+        <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-10 w-auto md:h-12" />
+        <div class="hidden text-sm text-gray-500 md:block">{{ t('sidebar.app_name') }}</div>
+      </div>
 
-    <div class="group flex items-center w-full max-w-2xl rounded-full bg-gray-200 transition-all duration-300 focus-within:bg-white focus-within:shadow-md border border-gray-300">
-      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-2">
-        <mat-icon [matTooltip]="t('search.tooltip')">search</mat-icon>
-      </button>
-
-      <input
-        matInput
-        [placeholder]="t('search.placeholder')"
-        class="flex-1 bg-transparent border-none focus:outline-none py-2"
-        [ngModel]="searchQuery"
-        (ngModelChange)="searchChange.emit($event)"
-        [matAutocomplete]="auto"
-      />
-
-      <mat-autocomplete #auto="matAutocomplete" (optionSelected)="suggestionSelected.emit($event.option.value)">
-        @for (suggestion of suggestions; track suggestion) {
-          <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
-        }
-      </mat-autocomplete>
-
-      @if (searchQuery) {
-        <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-2" (click)="clearSearch.emit()">
-          <mat-icon>close</mat-icon>
+      <div class="group flex w-full items-center rounded-xl border border-gray-300 bg-gray-200/70 px-2 transition-all duration-300 focus-within:border-blue-300 focus-within:bg-white focus-within:shadow-md xl:max-w-2xl">
+        <button mat-icon-button class="!h-9 !w-9" [matTooltip]="t('search.tooltip')">
+          <mat-icon>search</mat-icon>
         </button>
-      } @else {
-        <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!w-10 !h-10 flex items-center justify-center m-2">
-          <mat-icon class="text-gray-500" [matTooltip]="t('search.filter_tooltip')">tune</mat-icon>
-        </button>
-      }
 
-      <mat-menu #filterMenu="matMenu">
-        <button mat-menu-item disabled><span class="font-medium">{{ t('search.filter_by') }}</span></button>
-        <mat-divider></mat-divider>
-        @for (col of availableColumns; track col.value) {
-          <button mat-menu-item (click)="advancedFilterChange.emit(col.value)" [class.bg-blue-50]="advancedFilterColumn === col.value">
-            <mat-icon>{{ col.icon }}</mat-icon>
-            <span>{{ t('search.columns.' + col.value) }}</span>
-            @if (advancedFilterColumn === col.value) {
-              <mat-icon class="ml-auto text-blue-500">check</mat-icon>
-            }
+        <input
+          matInput
+          [placeholder]="t('search.placeholder')"
+          class="min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
+          [ngModel]="searchQuery"
+          (ngModelChange)="searchChange.emit($event)"
+          [matAutocomplete]="auto"
+        />
+
+        <mat-autocomplete #auto="matAutocomplete" (optionSelected)="suggestionSelected.emit($event.option.value)">
+          @for (suggestion of suggestions; track suggestion) {
+            <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
+          }
+        </mat-autocomplete>
+
+        @if (searchQuery) {
+          <button mat-icon-button class="!h-9 !w-9" (click)="clearSearch.emit()">
+            <mat-icon>close</mat-icon>
+          </button>
+        } @else {
+          <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!h-9 !w-9">
+            <mat-icon [matTooltip]="t('search.filter_tooltip')">tune</mat-icon>
           </button>
         }
-      </mat-menu>
+
+        <mat-menu #filterMenu="matMenu">
+          <button mat-menu-item disabled><span class="font-medium">{{ t('search.filter_by') }}</span></button>
+          <mat-divider></mat-divider>
+          @for (col of availableColumns; track col.value) {
+            <button mat-menu-item (click)="advancedFilterChange.emit(col.value)" [class.bg-blue-50]="advancedFilterColumn === col.value">
+              <mat-icon>{{ col.icon }}</mat-icon>
+              <span>{{ t('search.columns.' + col.value) }}</span>
+              @if (advancedFilterColumn === col.value) {
+                <mat-icon class="ml-auto text-blue-500">check</mat-icon>
+              }
+            </button>
+          }
+        </mat-menu>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-end gap-1 md:gap-2">
+        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="themeToggle.emit()" [matTooltip]="t('toolbar.theme')">
+          <mat-icon>{{ isDarkTheme ? 'light_mode' : 'dark_mode' }}</mat-icon>
+        </button>
+
+        <button
+          mat-icon-button
+          class="!h-9 !w-9 rounded-lg"
+          [matBadge]="unreadNotifications"
+          [matBadgeHidden]="unreadNotifications === 0"
+          matBadgeColor="warn"
+          matBadgeSize="large"
+          (click)="notificationOpen.emit()"
+          [matTooltip]="t('toolbar.notifications')"
+        >
+          <mat-icon>notifications</mat-icon>
+        </button>
+
+        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
+          <mat-icon>{{ viewMode === 'table' ? 'view_module' : 'table_chart' }}</mat-icon>
+        </button>
+
+        <app-set-language></app-set-language>
+
+        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
+          <mat-icon>help_outline</mat-icon>
+        </button>
+
+        @if (currentUser) {
+          <span [matBadge]="currentUser.status" [matBadgeHidden]="!currentUser.status" [ngClass]="getBadgeClass(currentUser.status)" matBadgeSize="large" matBadgeOverlap="true">
+            <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="!h-9 !w-9 rounded-lg" [matTooltip]="t('toolbar.profile')">
+              @if (currentUser.profilePicture) {
+                <img [src]="currentUser.profilePicture" class="h-8 w-8 rounded-full object-cover" [alt]="t('toolbar.profile')" />
+              } @else {
+                <mat-icon>account_circle</mat-icon>
+              }
+            </button>
+          </span>
+        }
+
+        <mat-menu #profileMenu="matMenu">
+          <button mat-menu-item (click)="profileOpen.emit()"><mat-icon>person</mat-icon><span>{{ t('toolbar.profile') }}</span></button>
+          <button mat-menu-item (click)="activityLogsOpen.emit()"><mat-icon>history</mat-icon><span>{{ 'toolbar.activity_log' | transloco }}</span></button>
+          <button mat-menu-item (click)="logout.emit()" [routerLink]="['/login']"><mat-icon>logout</mat-icon><span>{{ t('toolbar.logout') }}</span></button>
+        </mat-menu>
+      </div>
     </div>
 
-    <div class="flex items-center gap-1 md:gap-4">
-      <button mat-icon-button (click)="themeToggle.emit()" class="!w-10 !h-10 flex items-center justify-center" [matTooltip]="t('toolbar.theme')">
-        <mat-icon>{{ isDarkTheme ? 'light_mode' : 'dark_mode' }}</mat-icon>
-      </button>
+    @if (advancedFilterColumn !== 'all') {
+      <div class="mt-2 inline-flex items-center rounded-full bg-gray-200 px-3 py-1 text-xs text-gray-600">
+        <mat-icon class="!text-sm">filter_alt</mat-icon>
+        <span class="ml-1">{{ t('search.filtering_in') }}</span>
+        <span class="ml-1 font-semibold">{{ t('search.columns.' + advancedFilterColumn) }}</span>
+      </div>
+    }
+  </section>
 
-      <button
-        mat-icon-button
-        [matBadge]="unreadNotifications"
-        [matBadgeHidden]="unreadNotifications === 0"
-        matBadgeColor="warn"
-        matBadgeSize="large"
-        class="!w-10 !h-10 flex items-center justify-center relative"
-        (click)="notificationOpen.emit()"
-        [matTooltip]="t('toolbar.notifications')"
-      >
-        <mat-icon>notifications</mat-icon>
-      </button>
+  <section class="grid grid-cols-1 gap-3 rounded-2xl border border-gray-200/70 bg-white p-3 shadow-[0_6px_18px_rgba(15,23,42,0.04)] md:grid-cols-3 md:items-center md:p-4">
+    <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!flex !w-full !border-none rounded-xl bg-gray-200 p-1 md:col-span-1">
+      <mat-button-toggle value="coming" class="!flex-1 !rounded-lg !border-none !font-medium">{{ t('anniversary.coming') }}</mat-button-toggle>
+      <mat-button-toggle value="passed" class="!flex-1 !rounded-lg !border-none !font-medium">{{ t('anniversary.passed') }}</mat-button-toggle>
+    </mat-button-toggle-group>
 
-      <button mat-icon-button (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
-        <mat-icon>{{ viewMode === 'table' ? 'view_module' : 'table_chart' }}</mat-icon>
-      </button>
-
-      <app-set-language></app-set-language>
-
-      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
-        <mat-icon>help_outline</mat-icon>
-      </button>
-
-      @if (currentUser) {
-        <span [matBadge]="currentUser.status" [matBadgeHidden]="!currentUser.status" [ngClass]="getBadgeClass(currentUser.status)" matBadgeSize="large" matBadgeOverlap="true">
-          <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="flex items-center justify-center" [matTooltip]="t('toolbar.profile')">
-            @if (currentUser.profilePicture) {
-              <img [src]="currentUser.profilePicture" class="rounded-full h-8 w-8" [alt]="t('toolbar.profile')" />
-            } @else {
-              <mat-icon>account_circle</mat-icon>
-            }
-          </button>
-        </span>
-      }
-
-      <mat-menu #profileMenu="matMenu">
-        <button mat-menu-item (click)="profileOpen.emit()"><mat-icon>person</mat-icon><span>{{ t('toolbar.profile') }}</span></button>
-        <button mat-menu-item (click)="activityLogsOpen.emit()"><mat-icon>history</mat-icon><span>{{ 'toolbar.activity_log' | transloco }}</span></button>
-        <button mat-menu-item (click)="logout.emit()" [routerLink]="['/login']"><mat-icon>logout</mat-icon><span>{{ t('toolbar.logout') }}</span></button>
-      </mat-menu>
+    <div class="flex items-center justify-center gap-2 rounded-xl bg-gray-200/50 px-3 py-2">
+      <mat-icon class="text-gray-500">calendar_today</mat-icon>
+      <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
     </div>
-  </div>
-
-  @if (advancedFilterColumn !== 'all') {
-    <div class="text-sm text-gray-500 mt-1 ml-60 flex items-center">
-      <mat-icon class="!text-sm mr-1">filter_alt</mat-icon>
-      {{ t('search.filtering_in') }}
-      <span class="font-medium ml-1">{{ t('search.columns.' + advancedFilterColumn) }}</span>
+    <div class="flex items-center justify-center gap-2 rounded-xl bg-gray-200/50 px-3 py-2">
+      <mat-icon class="text-gray-500">schedule</mat-icon>
+      <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
     </div>
-  }
-</div>
-
-<div class="bg-white flex shadow-md justify-center gap-5 rounded-lg p-4 mt-4" *transloco="let t">
-  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-gray-200 p-1">
-    <mat-button-toggle value="coming" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'coming'">
-      {{ t('anniversary.coming') }}
-    </mat-button-toggle>
-    <mat-button-toggle value="passed" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'passed'">
-      {{ t('anniversary.passed') }}
-    </mat-button-toggle>
-  </mat-button-toggle-group>
-
-  <div class="flex items-center gap-2">
-    <mat-icon class="text-gray-500">calendar_today</mat-icon>
-    <span class="font-medium text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
-  </div>
-  <div class="flex items-center gap-2">
-    <mat-icon class="text-gray-500">schedule</mat-icon>
-    <span class="font-medium text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
-  </div>
+  </section>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
@@ -1,13 +1,13 @@
 <div class="space-y-4" *transloco="let t">
-  <section class="rounded-2xl border border-gray-200/70 bg-white p-3 shadow-[0_10px_28px_rgba(15,23,42,0.05)] md:p-4">
-    <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+  <section class="dashboard-card rounded-2xl border border-gray-200/70 bg-white p-3 md:p-4">
+    <div class="flex flex-col gap-3 2xl:flex-row 2xl:items-center 2xl:justify-between">
       <div class="flex items-center gap-3">
         <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-10 w-auto md:h-12" />
         <div class="hidden text-sm text-gray-500 md:block">{{ t('sidebar.app_name') }}</div>
       </div>
 
-      <div class="group flex w-full items-center rounded-xl border border-gray-300 bg-gray-200/70 px-2 transition-all duration-300 focus-within:border-blue-300 focus-within:bg-white focus-within:shadow-md xl:max-w-2xl">
-        <button mat-icon-button class="!h-9 !w-9" [matTooltip]="t('search.tooltip')">
+      <div class="group flex w-full items-center rounded-xl border border-gray-300 bg-gray-200/80 px-2 transition-all duration-300 focus-within:border-blue-400 focus-within:bg-white xl:max-w-2xl">
+        <button mat-icon-button class="dashboard-icon-btn" [matTooltip]="t('search.tooltip')">
           <mat-icon>search</mat-icon>
         </button>
 
@@ -27,11 +27,11 @@
         </mat-autocomplete>
 
         @if (searchQuery) {
-          <button mat-icon-button class="!h-9 !w-9" (click)="clearSearch.emit()">
+          <button mat-icon-button class="dashboard-icon-btn" (click)="clearSearch.emit()">
             <mat-icon>close</mat-icon>
           </button>
         } @else {
-          <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!h-9 !w-9">
+          <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="dashboard-icon-btn">
             <mat-icon [matTooltip]="t('search.filter_tooltip')">tune</mat-icon>
           </button>
         }
@@ -51,14 +51,14 @@
         </mat-menu>
       </div>
 
-      <div class="flex flex-wrap items-center justify-end gap-1 md:gap-2">
-        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="themeToggle.emit()" [matTooltip]="t('toolbar.theme')">
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        <button mat-icon-button class="dashboard-icon-btn" (click)="themeToggle.emit()" [matTooltip]="t('toolbar.theme')">
           <mat-icon>{{ isDarkTheme ? 'light_mode' : 'dark_mode' }}</mat-icon>
         </button>
 
         <button
           mat-icon-button
-          class="!h-9 !w-9 rounded-lg"
+          class="dashboard-icon-btn"
           [matBadge]="unreadNotifications"
           [matBadgeHidden]="unreadNotifications === 0"
           matBadgeColor="warn"
@@ -69,19 +69,19 @@
           <mat-icon>notifications</mat-icon>
         </button>
 
-        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
+        <button mat-icon-button class="dashboard-icon-btn" (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
           <mat-icon>{{ viewMode === 'table' ? 'view_module' : 'table_chart' }}</mat-icon>
         </button>
 
         <app-set-language></app-set-language>
 
-        <button mat-icon-button class="!h-9 !w-9 rounded-lg" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
+        <button mat-icon-button class="dashboard-icon-btn" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
           <mat-icon>help_outline</mat-icon>
         </button>
 
         @if (currentUser) {
           <span [matBadge]="currentUser.status" [matBadgeHidden]="!currentUser.status" [ngClass]="getBadgeClass(currentUser.status)" matBadgeSize="large" matBadgeOverlap="true">
-            <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="!h-9 !w-9 rounded-lg" [matTooltip]="t('toolbar.profile')">
+            <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="dashboard-icon-btn" [matTooltip]="t('toolbar.profile')">
               @if (currentUser.profilePicture) {
                 <img [src]="currentUser.profilePicture" class="h-8 w-8 rounded-full object-cover" [alt]="t('toolbar.profile')" />
               } @else {
@@ -100,7 +100,7 @@
     </div>
 
     @if (advancedFilterColumn !== 'all') {
-      <div class="mt-2 inline-flex items-center rounded-full bg-gray-200 px-3 py-1 text-xs text-gray-600">
+      <div class="mt-2 inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs text-blue-700">
         <mat-icon class="!text-sm">filter_alt</mat-icon>
         <span class="ml-1">{{ t('search.filtering_in') }}</span>
         <span class="ml-1 font-semibold">{{ t('search.columns.' + advancedFilterColumn) }}</span>
@@ -108,19 +108,24 @@
     }
   </section>
 
-  <section class="grid grid-cols-1 gap-3 rounded-2xl border border-gray-200/70 bg-white p-3 shadow-[0_6px_18px_rgba(15,23,42,0.04)] md:grid-cols-3 md:items-center md:p-4">
+  <section class="dashboard-card grid grid-cols-1 gap-3 rounded-2xl border border-gray-200/70 bg-white p-3 md:grid-cols-3 md:items-center md:p-4">
     <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!flex !w-full !border-none rounded-xl bg-gray-200 p-1 md:col-span-1">
       <mat-button-toggle value="coming" class="!flex-1 !rounded-lg !border-none !font-medium">{{ t('anniversary.coming') }}</mat-button-toggle>
       <mat-button-toggle value="passed" class="!flex-1 !rounded-lg !border-none !font-medium">{{ t('anniversary.passed') }}</mat-button-toggle>
     </mat-button-toggle-group>
 
-    <div class="flex items-center justify-center gap-2 rounded-xl bg-gray-200/50 px-3 py-2">
-      <mat-icon class="text-gray-500">calendar_today</mat-icon>
-      <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
+    <div class="rounded-xl border border-gray-200 bg-gray-200/50 px-3 py-2 text-center">
+      <div class="flex items-center justify-center gap-2">
+        <mat-icon class="text-gray-500">calendar_today</mat-icon>
+        <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
+      </div>
     </div>
-    <div class="flex items-center justify-center gap-2 rounded-xl bg-gray-200/50 px-3 py-2">
-      <mat-icon class="text-gray-500">schedule</mat-icon>
-      <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
+
+    <div class="rounded-xl border border-gray-200 bg-gray-200/50 px-3 py-2 text-center">
+      <div class="flex items-center justify-center gap-2">
+        <mat-icon class="text-gray-500">schedule</mat-icon>
+        <span class="text-sm font-semibold text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
+      </div>
     </div>
   </section>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -1,10 +1,8 @@
-<div class="flex h-screen w-full overflow-hidden bg-gray-200">
+<div class="flex min-h-screen w-full overflow-hidden bg-gray-200/60">
   <app-aside-nav-bar class="h-full shrink-0"></app-aside-nav-bar>
 
-  <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
-    
-    <main class="flex-1 flex flex-col p-4 overflow-hidden">
-      
+  <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+    <main class="mx-auto flex h-full w-full max-w-[1680px] flex-1 flex-col gap-4 p-3 md:p-5 lg:p-6">
       <app-landing-page-header
         class="shrink-0"
         [viewMode]="viewMode"
@@ -31,9 +29,9 @@
         (activeButtonChange)="activeButtonChange.emit($event)"
       ></app-landing-page-header>
 
-      <div class="flex-1 overflow-hidden mt-4 rounded-lg bg-white shadow-sm flex flex-col">
+      <section class="relative flex min-h-0 flex-1 overflow-hidden rounded-2xl border border-gray-200/70 bg-white shadow-[0_10px_40px_rgba(15,23,42,0.06)]">
         <app-landing-page-content
-          class="flex-1 flex flex-col min-h-0" 
+          class="flex min-h-0 flex-1 flex-col"
           [isLoading]="isLoading"
           [viewMode]="viewMode"
           [hasBirthdays]="hasBirthdays"
@@ -44,10 +42,9 @@
           (birthdayDetails)="birthdayDetails.emit($event)"
           (refresh)="refresh.emit()"
         ></app-landing-page-content>
-      </div>
+      </section>
 
-      <app-footer class="shrink-0 pt-4"></app-footer>
-      
+      <app-footer class="shrink-0"></app-footer>
     </main>
   </div>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -1,8 +1,8 @@
-<div class="flex min-h-screen w-full overflow-hidden bg-gray-200/60">
+<div class="dashboard-shell flex h-screen w-full overflow-hidden bg-gray-200/60">
   <app-aside-nav-bar class="h-full shrink-0"></app-aside-nav-bar>
 
   <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
-    <main class="mx-auto flex h-full w-full max-w-[1680px] flex-1 flex-col gap-4 p-3 md:p-5 lg:p-6">
+    <main class="flex h-full w-full flex-1 flex-col gap-4 p-3 md:gap-5 md:p-5 lg:p-6">
       <app-landing-page-header
         class="shrink-0"
         [viewMode]="viewMode"
@@ -29,7 +29,7 @@
         (activeButtonChange)="activeButtonChange.emit($event)"
       ></app-landing-page-header>
 
-      <section class="relative flex min-h-0 flex-1 overflow-hidden rounded-2xl border border-gray-200/70 bg-white shadow-[0_10px_40px_rgba(15,23,42,0.06)]">
+      <section class="dashboard-card relative flex min-h-0 flex-1 overflow-hidden rounded-2xl border border-gray-200/70 bg-white">
         <app-landing-page-content
           class="flex min-h-0 flex-1 flex-col"
           [isLoading]="isLoading"

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -421,3 +421,64 @@ mat-dialog-content,
         color: white !important;
     }
 }
+
+/* Dashboard UI refresh helpers */
+.dashboard-shell {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 75%, #eef4ff 25%) 0%, var(--bg-primary) 100%);
+}
+
+.dashboard-card {
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+.dashboard-icon-btn {
+  height: 2.25rem !important;
+  width: 2.25rem !important;
+  border-radius: 0.7rem !important;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: var(--border-color);
+    background-color: var(--bg-secondary);
+  }
+}
+
+.dashboard-action-btn {
+  border-radius: 0.65rem !important;
+  border-color: var(--border-color) !important;
+  color: var(--text-primary) !important;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: var(--bg-secondary) !important;
+    transform: translateY(-1px);
+  }
+}
+
+.dashboard-nav-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0.45rem 0.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid transparent;
+  background: transparent;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: var(--border-color);
+    background-color: var(--bg-secondary);
+  }
+}
+
+.dashboard-nav-icon {
+  height: 2.25rem;
+  width: 2.25rem;
+  min-width: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.7rem;
+  background-color: color-mix(in srgb, var(--bg-secondary) 75%, #dbeafe 25%);
+}


### PR DESCRIPTION
### Motivation
- Refresh the dashboard UI to a modern, clean SaaS-style design while preserving all existing functionality and event bindings. 
- Improve readability and visual hierarchy by reorganizing header, content and sidebar areas and making spacing and alignment more consistent. 
- Make the layout more responsive and prepare the interface for both light and dark themes using the existing CSS variable theme system. 

### Description
- Reworked the landing page shell to a centered max-width workspace with rounded card surfaces and stronger spacing by editing `landing-page-view.component.html`. 
- Revamped the header into two card-like sections with an improved search bar, grouped actions, compact filter chip and clearer date/time display by updating `landing-page-header.component.html`. 
- Improved the content area with polished loading/empty states, a compact table toolbar and a responsive card grid for card view by updating `landing-page-content.component.html`. 
- Restyled the sidebar to use rounded action items, softer backgrounds and smoother transitions while keeping the same behavior by updating `aside-nav-bar.component.html`. 

### Testing
- `npm run build -- --configuration development` completed successfully and produced the application bundle. 
- `npm run build` (production) failed in this environment due to font inlining from Google Fonts returning HTTP 403, which is an environment/network restriction and not related to the UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea97e67f483328f68a2bc6b320ba3)