### PR TITLE
feat(ui): modernize Time2Wish dashboard UX with responsive Material + Tailwind polish

### DIFF
--- a/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
+++ b/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
@@ -1,14 +1,14 @@
 <aside
-  class="sticky top-0 left-0 h-screen bg-white flex flex-col items-center transition-all duration-200 ease-in-out shadow-sm border-r border-gray-100"
+  class="sticky top-0 left-0 h-screen bg-white/95 backdrop-blur-sm flex flex-col items-center transition-all duration-200 ease-in-out shadow-md border-r border-gray-200"
   [class.w-16]="!expanded()"
   [class.px-4]="expanded()"
   [style.width]="expanded() ? '280px' : '5rem'"
 >
-  <div class="flex flex-col mt-6 w-full gap-1.5 px-2" *transloco="let t">
+  <div class="flex flex-col mt-6 w-full gap-2 px-2.5" *transloco="let t">
     
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left min-h-11"
       [class.bg-indigo-50]="activeItem() === 'menu'"
       [class.ring-1]="activeItem() === 'menu'"
       [class.ring-indigo-200]="activeItem() === 'menu'"
@@ -28,7 +28,7 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left min-h-11"
       [class.bg-indigo-50]="activeItem() === 'settings'"
       [class.ring-1]="activeItem() === 'settings'"
       [class.ring-indigo-200]="activeItem() === 'settings'"
@@ -48,7 +48,7 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left min-h-11"
       [class.bg-indigo-50]="activeItem() === 'add'"
       [class.ring-1]="activeItem() === 'add'"
       [class.ring-indigo-200]="activeItem() === 'add'"
@@ -68,7 +68,7 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left min-h-11"
       [class.bg-indigo-50]="activeItem() === 'stats'"
       [class.ring-1]="activeItem() === 'stats'"
       [class.ring-indigo-200]="activeItem() === 'stats'"
@@ -88,7 +88,7 @@
     
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left min-h-11"
       [class.bg-indigo-50]="activeItem() === 'pricing'"
       [class.ring-1]="activeItem() === 'pricing'"
       [class.ring-indigo-200]="activeItem() === 'pricing'"
@@ -108,7 +108,7 @@
   </div>
 
   <div class="w-full p-4 mt-auto">
-    <div class="flex flex-col items-center" *transloco="let t">
+    <div class="flex flex-col items-center rounded-xl bg-slate-100/80 p-2.5 border border-slate-200" *transloco="let t">
       <div class="flex items-center justify-center gap-2">
         <img
           src="time2wish-logo.png"

--- a/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
+++ b/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.html
@@ -1,14 +1,17 @@
 <aside
-  class="sticky top-0 left-0 h-screen bg-white flex flex-col items-center transition-all duration-100 ease-in-out shadow-sm border-r border-gray-100"
+  class="sticky top-0 left-0 h-screen bg-white flex flex-col items-center transition-all duration-200 ease-in-out shadow-sm border-r border-gray-100"
   [class.w-16]="!expanded()"
   [class.px-4]="expanded()"
   [style.width]="expanded() ? '280px' : '5rem'"
 >
-  <div class="flex flex-col mt-10 w-full gap-2" *transloco="let t">
+  <div class="flex flex-col mt-6 w-full gap-1.5 px-2" *transloco="let t">
     
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      [class.bg-indigo-50]="activeItem() === 'menu'"
+      [class.ring-1]="activeItem() === 'menu'"
+      [class.ring-indigo-200]="activeItem() === 'menu'"
       (click)="toggleSidebar()"
       [matTooltip]="!expanded() ? t('sidebar.menu') : ''"
       matTooltipPosition="right"
@@ -25,7 +28,10 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      [class.bg-indigo-50]="activeItem() === 'settings'"
+      [class.ring-1]="activeItem() === 'settings'"
+      [class.ring-indigo-200]="activeItem() === 'settings'"
       (click)="onSetting()"
       [matTooltip]="!expanded() ? t('sidebar.settings') : ''"
       matTooltipPosition="right"
@@ -42,7 +48,10 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      [class.bg-indigo-50]="activeItem() === 'add'"
+      [class.ring-1]="activeItem() === 'add'"
+      [class.ring-indigo-200]="activeItem() === 'add'"
       (click)="onAddBirthday()"
       [matTooltip]="!expanded() ? t('sidebar.add_user') : ''"
       matTooltipPosition="right"
@@ -59,7 +68,10 @@
 
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      [class.bg-indigo-50]="activeItem() === 'stats'"
+      [class.ring-1]="activeItem() === 'stats'"
+      [class.ring-indigo-200]="activeItem() === 'stats'"
       (click)="onStatistics()"
       [matTooltip]="!expanded() ? t('sidebar.statistics') : ''"
       matTooltipPosition="right"
@@ -76,7 +88,10 @@
     
     <button
       type="button"
-      class="flex items-center w-full hover:bg-gray-100 transition-colors rounded-lg bg-transparent border-none p-0 text-left"
+      class="flex items-center w-full hover:bg-gray-100 transition-all duration-200 rounded-xl bg-transparent border-none p-0 text-left"
+      [class.bg-indigo-50]="activeItem() === 'pricing'"
+      [class.ring-1]="activeItem() === 'pricing'"
+      [class.ring-indigo-200]="activeItem() === 'pricing'"
       (click)="onPricing()"
       [matTooltip]="!expanded() ? t('sidebar.pricing') : ''"
       matTooltipPosition="right"

--- a/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.ts
+++ b/front-end/src/app/components/aside-nav-bar/aside-nav-bar.component.ts
@@ -42,6 +42,7 @@ export class AsideNavBarComponent implements OnInit {
   // Signals for local state management
   readonly expanded = signal(false);
   readonly version = signal('');
+  readonly activeItem = signal<'menu' | 'settings' | 'add' | 'stats' | 'pricing'>('menu');
 
   ngOnInit(): void {
     // Setting signal value from service
@@ -49,22 +50,27 @@ export class AsideNavBarComponent implements OnInit {
   }
 
   toggleSidebar(): void {
+    this.activeItem.set('menu');
     this.expanded.update((val) => !val);
   }
 
   onSetting(): void {
+    this.activeItem.set('settings');
     this.dialog.open(SettingComponent);
   }
 
   onAddBirthday(): void {
+    this.activeItem.set('add');
     this.dialog.open(NewBirthdayComponent);
   }
 
   onStatistics(): void {
+    this.activeItem.set('stats');
     this.dialog.open(StatisticComponent);
   }
 
   onPricing(): void {
+    this.activeItem.set('pricing');
     this.dialog.open(PricingComponent);
   }
 }

--- a/front-end/src/app/components/birthday-table/birthday-table.component.html
+++ b/front-end/src/app/components/birthday-table/birthday-table.component.html
@@ -1,19 +1,19 @@
 <div class="flex flex-col min-h-0 max-h-full overflow-hidden">
-  <div  class=" flex-1 overflow-y-auto mat-elevation-z8">
-    <table mat-table [dataSource]="dataSource" matSort class="w-full">
+  <div class="flex-1 overflow-auto mat-elevation-z8">
+    <table mat-table [dataSource]="dataSource" matSort class="w-full min-w-[860px]">
       <!-- Colonne Photo (non triable) -->
       <ng-container matColumnDef="photo">
         <th
           mat-header-cell
           *matHeaderCellDef
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.photo" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
           @if (element.photo) {
           <img
@@ -36,16 +36,16 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.name" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
-          <button mat-button (click)="openBirthdayDetails(element)">
+          <button mat-button class="!px-2 !py-1 !rounded-lg hover:!bg-gray-100 transition-all duration-200" (click)="openBirthdayDetails(element)">
             {{ element.name }}
           </button>
         </td>
@@ -57,14 +57,14 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.city" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
           {{ element.city | transloco }}
         </td>
@@ -76,16 +76,18 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.category" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
-          {{ element.category | transloco }}
+          <span class="inline-flex rounded-full bg-indigo-100 text-indigo-700 px-2.5 py-1 text-xs font-semibold">
+            {{ element.category | transloco }}
+          </span>
         </td>
       </ng-container>
 
@@ -95,14 +97,14 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.date" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
           {{ element.date | date : "dd.MM.yyyy" }}
         </td>
@@ -114,16 +116,16 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.age" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
-          <div class="flex items-center gap-1">
+          <div class="inline-flex items-center gap-1 rounded-full bg-amber-100 text-amber-700 px-2.5 py-1 text-xs font-semibold">
             <mat-icon class="!text-base !text-yellow-500">cake</mat-icon>
             <span>{{ calculateAge(element.date) }}</span>
           </div>
@@ -136,17 +138,17 @@
           mat-header-cell
           *matHeaderCellDef
           mat-sort-header
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.status" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
           <div
-            class="flex items-center gap-1"
+            class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold bg-gray-100"
             [ngClass]="getBirthdayStatus(element.date).color"
           >
             <mat-icon class="!text-base">{{
@@ -162,25 +164,24 @@
         <th
           mat-header-cell
           *matHeaderCellDef
-          class="bg-gray-50 font-semibold text-gray-700"
+          class="bg-gray-50 font-semibold text-gray-700 text-xs md:text-sm uppercase tracking-wide"
         >
           {{ "birthday_table.action" | transloco }}
         </th>
         <td
           mat-cell
           *matCellDef="let element"
-          class="text-gray-600 border-t border-gray-200"
+          class="text-gray-600 border-t border-gray-200 py-3"
         >
           <div class="flex gap-2">
-            <button mat-icon-button color="primary" (click)="editBirthday(element)">
+            <button mat-icon-button color="primary" class="hover:!bg-indigo-100 transition-all duration-200" (click)="editBirthday(element)" [attr.aria-label]="'birthday_table.edit' | transloco">
               <mat-icon matTooltip="{{ 'birthday_table.edit' | transloco }}"
                 >edit</mat-icon
               >
             </button>
-            <button mat-icon-button color="warn">
+            <button mat-icon-button color="warn" class="hover:!bg-rose-100 transition-all duration-200" (click)="deleteBirthday(element.id)" [attr.aria-label]="'birthday_table.delete' | transloco">
               <mat-icon
                 matTooltip="{{ 'birthday_table.delete' | transloco }}"
-                (click)="deleteBirthday(element.id)"
               >
                 delete
               </mat-icon>
@@ -189,8 +190,8 @@
         </td>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true" class="sticky top-0 z-10"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="hover:bg-gray-100 transition-all duration-200 even:bg-gray-50/60"></tr>
     </table>
   </div>
 
@@ -199,7 +200,7 @@
     [pageSize]="pageSize"
     showFirstLastButtons
     aria-label="Select page of birthdays"
-    class="border-t"
+    class="border-t bg-white"
   >
   </mat-paginator>
 </div>

--- a/front-end/src/app/components/birthday-table/birthday-table.component.html
+++ b/front-end/src/app/components/birthday-table/birthday-table.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-col min-h-0 max-h-full overflow-hidden">
-  <div class="flex-1 overflow-auto mat-elevation-z8">
+  <div class="flex-1 overflow-auto mat-elevation-z8 rounded-xl border border-gray-200">
     <table mat-table [dataSource]="dataSource" matSort class="w-full min-w-[860px]">
       <!-- Colonne Photo (non triable) -->
       <ng-container matColumnDef="photo">
@@ -45,7 +45,7 @@
           *matCellDef="let element"
           class="text-gray-600 border-t border-gray-200 py-3"
         >
-          <button mat-button class="!px-2 !py-1 !rounded-lg hover:!bg-gray-100 transition-all duration-200" (click)="openBirthdayDetails(element)">
+          <button mat-button class="!px-2 !py-1 !rounded-lg !font-semibold !text-indigo-600 hover:!bg-indigo-50 transition-all duration-200" (click)="openBirthdayDetails(element)">
             {{ element.name }}
           </button>
         </td>
@@ -85,7 +85,7 @@
           *matCellDef="let element"
           class="text-gray-600 border-t border-gray-200 py-3"
         >
-          <span class="inline-flex rounded-full bg-indigo-100 text-indigo-700 px-2.5 py-1 text-xs font-semibold">
+          <span class="inline-flex rounded-full bg-indigo-100 text-indigo-700 px-2.5 py-1 text-xs font-semibold ring-1 ring-indigo-200">
             {{ element.category | transloco }}
           </span>
         </td>
@@ -125,7 +125,7 @@
           *matCellDef="let element"
           class="text-gray-600 border-t border-gray-200 py-3"
         >
-          <div class="inline-flex items-center gap-1 rounded-full bg-amber-100 text-amber-700 px-2.5 py-1 text-xs font-semibold">
+          <div class="inline-flex items-center gap-1 rounded-full bg-amber-100 text-amber-700 px-2.5 py-1 text-xs font-semibold ring-1 ring-amber-200">
             <mat-icon class="!text-base !text-yellow-500">cake</mat-icon>
             <span>{{ calculateAge(element.date) }}</span>
           </div>
@@ -174,12 +174,12 @@
           class="text-gray-600 border-t border-gray-200 py-3"
         >
           <div class="flex gap-2">
-            <button mat-icon-button color="primary" class="hover:!bg-indigo-100 transition-all duration-200" (click)="editBirthday(element)" [attr.aria-label]="'birthday_table.edit' | transloco">
+            <button mat-icon-button color="primary" class="dashboard-icon-btn hover:!bg-indigo-100 transition-all duration-200" (click)="editBirthday(element)" [attr.aria-label]="'birthday_table.edit' | transloco">
               <mat-icon matTooltip="{{ 'birthday_table.edit' | transloco }}"
                 >edit</mat-icon
               >
             </button>
-            <button mat-icon-button color="warn" class="hover:!bg-rose-100 transition-all duration-200" (click)="deleteBirthday(element.id)" [attr.aria-label]="'birthday_table.delete' | transloco">
+            <button mat-icon-button color="warn" class="dashboard-icon-btn hover:!bg-rose-100 transition-all duration-200" (click)="deleteBirthday(element.id)" [attr.aria-label]="'birthday_table.delete' | transloco">
               <mat-icon
                 matTooltip="{{ 'birthday_table.delete' | transloco }}"
               >

--- a/front-end/src/app/components/footer/footer.component.html
+++ b/front-end/src/app/components/footer/footer.component.html
@@ -1,17 +1,17 @@
-<footer class="shadow p-2 bg-white">
-  <div class="flex flex-col md:flex-row justify-between items-center">
-    <div class="mb-2 md:mb-0">
+<footer class="shadow-sm border border-gray-200 rounded-xl p-3 bg-white">
+  <div class="flex flex-col gap-3 md:gap-1 md:flex-row justify-between items-center">
+    <div class="mb-0">
       <p class="text-gray-600 text-xs mt-1">
         © {{ currentDate | date : "yyyy" }} Time2Wish.
         {{ 'footer.rights_reserved' | transloco }}
       </p>
     </div>
 
-    <div class="flex space-x-2">
+    <div class="flex flex-wrap justify-center gap-2">
       <button
         type="button"
         (click)="openModal('help')"
-        class="text-gray-600 hover:text-blue-600 transition text-xs flex items-center"
+        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">help_outline</mat-icon>
         <span class="ml-1">{{ 'footer.help' | transloco }}</span>
@@ -19,7 +19,7 @@
       <button
         type="button"
         (click)="openModal('conditions')"
-        class="text-gray-600 hover:text-blue-600 transition text-xs flex items-center"
+        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">description</mat-icon>
         <span class="ml-1">{{ 'footer.conditions' | transloco }}</span>
@@ -27,7 +27,7 @@
       <button
         type="button"
         (click)="openModal('confidentiality')"
-        class="text-gray-600 hover:text-blue-600 transition text-xs flex items-center"
+        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">privacy_tip</mat-icon>
         <span class="ml-1">{{ 'footer.confidentiality' | transloco }}</span>

--- a/front-end/src/app/components/footer/footer.component.html
+++ b/front-end/src/app/components/footer/footer.component.html
@@ -1,4 +1,4 @@
-<footer class="shadow-sm border border-gray-200 rounded-xl p-3 bg-white">
+<footer class="shadow-sm border border-gray-200/80 rounded-2xl p-3 bg-white/95 backdrop-blur-sm">
   <div class="flex flex-col gap-3 md:gap-1 md:flex-row justify-between items-center">
     <div class="mb-0">
       <p class="text-gray-600 text-xs mt-1">
@@ -11,7 +11,7 @@
       <button
         type="button"
         (click)="openModal('help')"
-        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
+        class="text-gray-600 hover:text-indigo-600 hover:bg-indigo-50 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">help_outline</mat-icon>
         <span class="ml-1">{{ 'footer.help' | transloco }}</span>
@@ -19,7 +19,7 @@
       <button
         type="button"
         (click)="openModal('conditions')"
-        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
+        class="text-gray-600 hover:text-indigo-600 hover:bg-indigo-50 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">description</mat-icon>
         <span class="ml-1">{{ 'footer.conditions' | transloco }}</span>
@@ -27,7 +27,7 @@
       <button
         type="button"
         (click)="openModal('confidentiality')"
-        class="text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
+        class="text-gray-600 hover:text-indigo-600 hover:bg-indigo-50 transition-all duration-200 text-xs flex items-center rounded-lg px-2 py-1"
       >
         <mat-icon class="text-base">privacy_tip</mat-icon>
         <span class="ml-1">{{ 'footer.confidentiality' | transloco }}</span>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -1,4 +1,4 @@
-<div class="mt-4 flex-1 bg-white rounded-xl shadow-sm overflow-hidden flex flex-col h-full border border-gray-200" *transloco="let t">
+<div class="mt-4 flex-1 bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col h-full border border-gray-200/80" *transloco="let t">
   
   @if (isLoading) {
     <div class="flex flex-col flex-1 items-center justify-center">
@@ -11,10 +11,10 @@
       @if (viewMode === 'table') {
         <div class="p-3 md:p-4 border-b border-gray-200 shrink-0 bg-white z-20">
           <div class="flex flex-wrap gap-2">
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-lg hover:bg-gray-100 transition-all duration-200">
+            <button mat-button class="dashboard-action-btn">
               <mat-icon>file_upload</mat-icon> {{ t('actions.import') }}
             </button>
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-lg hover:bg-gray-100 transition-all duration-200">
+            <button mat-button class="dashboard-action-btn">
               <mat-icon>file_download</mat-icon> {{ t('actions.export') }}
             </button>
           </div>
@@ -40,8 +40,10 @@
           }
         } @else {
           <div class="p-8 text-center text-gray-500 flex flex-col items-center justify-center h-full">
-            <mat-icon class="text-4xl mb-2 text-amber-500">event_busy</mat-icon>
-            <p>{{ t('anniversary.empty_coming') }}</p>
+            <div class="h-16 w-16 rounded-2xl bg-amber-100 flex items-center justify-center mb-3">
+              <mat-icon class="text-4xl text-amber-500">event_busy</mat-icon>
+            </div>
+            <p class="font-medium">{{ t('anniversary.empty_coming') }}</p>
           </div>
         }
       </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-content/landing-page-content.component.html
@@ -1,4 +1,4 @@
-<div class="mt-4 flex-1 bg-white rounded-lg shadow-lg overflow-hidden flex flex-col h-full" *transloco="let t">
+<div class="mt-4 flex-1 bg-white rounded-xl shadow-sm overflow-hidden flex flex-col h-full border border-gray-200" *transloco="let t">
   
   @if (isLoading) {
     <div class="flex flex-col flex-1 items-center justify-center">
@@ -9,12 +9,12 @@
     <div class="flex flex-col h-full min-h-0">
       
       @if (viewMode === 'table') {
-        <div class="p-4 border-b border-gray-200 shrink-0 bg-white z-20">
-          <div class="flex gap-2">
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-md">
+        <div class="p-3 md:p-4 border-b border-gray-200 shrink-0 bg-white z-20">
+          <div class="flex flex-wrap gap-2">
+            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-lg hover:bg-gray-100 transition-all duration-200">
               <mat-icon>file_upload</mat-icon> {{ t('actions.import') }}
             </button>
-            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-md">
+            <button mat-button class="flex items-center gap-1 border border-gray-200 px-3 py-1 rounded-lg hover:bg-gray-100 transition-all duration-200">
               <mat-icon>file_download</mat-icon> {{ t('actions.export') }}
             </button>
           </div>
@@ -32,7 +32,7 @@
               (refresh)="refresh.emit()">
             </app-birthday-table>
           } @else {
-            <div class="h-full overflow-y-auto p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 custom-scrollbar">
+            <div class="h-full overflow-y-auto p-4 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 custom-scrollbar">
               @for (item of filteredBirthdays; track item.id) {
                 <app-birthday-card [item]="item" ...></app-birthday-card>
               }
@@ -40,7 +40,7 @@
           }
         } @else {
           <div class="p-8 text-center text-gray-500 flex flex-col items-center justify-center h-full">
-            <mat-icon class="text-4xl mb-2">event_busy</mat-icon>
+            <mat-icon class="text-4xl mb-2 text-amber-500">event_busy</mat-icon>
             <p>{{ t('anniversary.empty_coming') }}</p>
           </div>
         }

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
@@ -1,18 +1,18 @@
-<div class="rounded-xl border border-gray-200 shadow-sm p-3 md:p-4 bg-white mt-3 md:mt-4" *transloco="let t">
+<div class="rounded-2xl border border-gray-200/80 shadow-md p-3 md:p-4 bg-white/95 backdrop-blur-sm mt-3 md:mt-4" *transloco="let t">
   <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between w-full">
     <div class="flex items-center justify-center xl:justify-start">
       <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-11 md:h-14 ml-1 md:ml-2" />
     </div>
 
-    <div class="group flex items-center w-full xl:max-w-2xl rounded-xl bg-gray-200 transition-all duration-200 focus-within:bg-white focus-within:shadow-md border border-gray-300">
-      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.tooltip')">
+    <div class="group flex items-center w-full xl:max-w-2xl rounded-xl bg-slate-100/90 transition-all duration-200 focus-within:bg-white focus-within:shadow-md border border-slate-300/80">
+      <button mat-icon-button class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.tooltip')">
         <mat-icon [matTooltip]="t('search.tooltip')">search</mat-icon>
       </button>
 
       <input
         matInput
         [placeholder]="t('search.placeholder')"
-        class="flex-1 bg-transparent border-none focus:outline-none py-2 text-sm md:text-base"
+        class="flex-1 bg-transparent border-none focus:outline-none py-2 text-sm md:text-base font-medium"
         [ngModel]="searchQuery"
         (ngModelChange)="searchChange.emit($event)"
         [matAutocomplete]="auto"
@@ -26,11 +26,11 @@
       </mat-autocomplete>
 
       @if (searchQuery) {
-        <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-1" (click)="clearSearch.emit()" [attr.aria-label]="t('search.placeholder')">
+        <button mat-icon-button class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center m-1" (click)="clearSearch.emit()" [attr.aria-label]="t('search.placeholder')">
           <mat-icon>close</mat-icon>
         </button>
       } @else {
-        <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.filter_tooltip')">
+        <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.filter_tooltip')">
           <mat-icon class="text-gray-500" [matTooltip]="t('search.filter_tooltip')">tune</mat-icon>
         </button>
       }
@@ -50,8 +50,8 @@
       </mat-menu>
     </div>
 
-    <div class="flex items-center justify-center xl:justify-end flex-wrap gap-1 md:gap-2 lg:gap-3">
-      <button mat-icon-button (click)="themeToggle.emit()" class="!w-10 !h-10 flex items-center justify-center" [matTooltip]="t('toolbar.theme')">
+    <div class="flex items-center justify-center xl:justify-end flex-wrap gap-1.5 md:gap-2 lg:gap-3">
+      <button mat-icon-button (click)="themeToggle.emit()" class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center" [matTooltip]="t('toolbar.theme')">
         <mat-icon>{{ isDarkTheme ? 'light_mode' : 'dark_mode' }}</mat-icon>
       </button>
 
@@ -61,26 +61,26 @@
         [matBadgeHidden]="unreadNotifications === 0"
         matBadgeColor="warn"
         matBadgeSize="large"
-        class="!w-10 !h-10 flex items-center justify-center relative"
+        class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center relative"
         (click)="notificationOpen.emit()"
         [matTooltip]="t('toolbar.notifications')"
       >
         <mat-icon>notifications</mat-icon>
       </button>
 
-      <button mat-icon-button (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')" [attr.aria-label]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
+      <button mat-icon-button class="dashboard-icon-btn !w-10 !h-10" (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')" [attr.aria-label]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
         <mat-icon>{{ viewMode === 'table' ? 'view_module' : 'table_chart' }}</mat-icon>
       </button>
 
       <app-set-language></app-set-language>
 
-      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
+      <button mat-icon-button class="dashboard-icon-btn !w-10 !h-10 flex items-center justify-center" (click)="informationOpen.emit()" [matTooltip]="t('toolbar.help')">
         <mat-icon>help_outline</mat-icon>
       </button>
 
       @if (currentUser) {
         <span [matBadge]="currentUser.status" [matBadgeHidden]="!currentUser.status" [ngClass]="getBadgeClass(currentUser.status)" matBadgeSize="large" matBadgeOverlap="true">
-          <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="flex items-center justify-center" [matTooltip]="t('toolbar.profile')">
+          <button mat-icon-button [matMenuTriggerFor]="profileMenu" class="dashboard-icon-btn flex items-center justify-center" [matTooltip]="t('toolbar.profile')">
             @if (currentUser.profilePicture) {
               <img [src]="currentUser.profilePicture" class="rounded-full h-8 w-8" [alt]="t('toolbar.profile')" />
             } @else {
@@ -99,7 +99,7 @@
   </div>
 
   @if (advancedFilterColumn !== 'all') {
-    <div class="text-xs sm:text-sm text-gray-500 mt-2 flex items-center gap-1">
+    <div class="text-xs sm:text-sm text-gray-500 mt-2 flex items-center gap-1 rounded-lg bg-indigo-50 px-3 py-1.5 w-fit">
       <mat-icon class="!text-sm mr-1">filter_alt</mat-icon>
       {{ t('search.filtering_in') }}
       <span class="font-medium ml-1">{{ t('search.columns.' + advancedFilterColumn) }}</span>
@@ -107,8 +107,8 @@
   }
 </div>
 
-<div class="bg-white border border-gray-200 flex flex-col sm:flex-row items-center shadow-sm justify-between gap-3 rounded-xl p-3 md:p-4 mt-4" *transloco="let t">
-  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-gray-200 p-1 shadow-sm">
+<div class="bg-white/95 border border-gray-200/80 flex flex-col lg:flex-row lg:items-center shadow-sm justify-between gap-3 rounded-2xl p-3 md:p-4 mt-4" *transloco="let t">
+  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-slate-100 p-1 shadow-sm">
     <mat-button-toggle value="coming" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'coming'">
       {{ t('anniversary.coming') }}
     </mat-button-toggle>
@@ -117,12 +117,12 @@
     </mat-button-toggle>
   </mat-button-toggle-group>
 
-  <div class="flex items-center gap-2 text-sm md:text-base">
-    <mat-icon class="text-gray-500">calendar_today</mat-icon>
+  <div class="flex items-center gap-2 text-sm md:text-base rounded-lg bg-slate-100 px-3 py-1.5">
+    <mat-icon class="text-indigo-500">calendar_today</mat-icon>
     <span class="font-medium text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
   </div>
-  <div class="flex items-center gap-2 text-sm md:text-base">
-    <mat-icon class="text-gray-500">schedule</mat-icon>
+  <div class="flex items-center gap-2 text-sm md:text-base rounded-lg bg-slate-100 px-3 py-1.5">
+    <mat-icon class="text-indigo-500">schedule</mat-icon>
     <span class="font-medium text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
   </div>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
@@ -1,21 +1,22 @@
-<div class="!rounded-lg !shadow-md !p-4 bg-white mt-4" *transloco="let t">
-  <div class="flex items-center justify-between w-full">
-    <div class="flex items-center">
-      <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-12 md:h-16 ml-2 md:ml-7" />
+<div class="rounded-xl border border-gray-200 shadow-sm p-3 md:p-4 bg-white mt-3 md:mt-4" *transloco="let t">
+  <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between w-full">
+    <div class="flex items-center justify-center xl:justify-start">
+      <img src="time2wish-logo.png" [alt]="t('toolbar.logo_alt')" class="h-11 md:h-14 ml-1 md:ml-2" />
     </div>
 
-    <div class="group flex items-center w-full max-w-2xl rounded-full bg-gray-200 transition-all duration-300 focus-within:bg-white focus-within:shadow-md border border-gray-300">
-      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-2">
+    <div class="group flex items-center w-full xl:max-w-2xl rounded-xl bg-gray-200 transition-all duration-200 focus-within:bg-white focus-within:shadow-md border border-gray-300">
+      <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.tooltip')">
         <mat-icon [matTooltip]="t('search.tooltip')">search</mat-icon>
       </button>
 
       <input
         matInput
         [placeholder]="t('search.placeholder')"
-        class="flex-1 bg-transparent border-none focus:outline-none py-2"
+        class="flex-1 bg-transparent border-none focus:outline-none py-2 text-sm md:text-base"
         [ngModel]="searchQuery"
         (ngModelChange)="searchChange.emit($event)"
         [matAutocomplete]="auto"
+        [attr.aria-label]="t('search.placeholder')"
       />
 
       <mat-autocomplete #auto="matAutocomplete" (optionSelected)="suggestionSelected.emit($event.option.value)">
@@ -25,11 +26,11 @@
       </mat-autocomplete>
 
       @if (searchQuery) {
-        <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-2" (click)="clearSearch.emit()">
+        <button mat-icon-button class="!w-10 !h-10 flex items-center justify-center m-1" (click)="clearSearch.emit()" [attr.aria-label]="t('search.placeholder')">
           <mat-icon>close</mat-icon>
         </button>
       } @else {
-        <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!w-10 !h-10 flex items-center justify-center m-2">
+        <button mat-icon-button [matMenuTriggerFor]="filterMenu" class="!w-10 !h-10 flex items-center justify-center m-1" [attr.aria-label]="t('search.filter_tooltip')">
           <mat-icon class="text-gray-500" [matTooltip]="t('search.filter_tooltip')">tune</mat-icon>
         </button>
       }
@@ -49,7 +50,7 @@
       </mat-menu>
     </div>
 
-    <div class="flex items-center gap-1 md:gap-4">
+    <div class="flex items-center justify-center xl:justify-end flex-wrap gap-1 md:gap-2 lg:gap-3">
       <button mat-icon-button (click)="themeToggle.emit()" class="!w-10 !h-10 flex items-center justify-center" [matTooltip]="t('toolbar.theme')">
         <mat-icon>{{ isDarkTheme ? 'light_mode' : 'dark_mode' }}</mat-icon>
       </button>
@@ -67,7 +68,7 @@
         <mat-icon>notifications</mat-icon>
       </button>
 
-      <button mat-icon-button (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
+      <button mat-icon-button (click)="viewToggle.emit(nextViewMode)" [matTooltip]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')" [attr.aria-label]="viewMode === 'table' ? t('toolbar.view_cards') : t('toolbar.view_table')">
         <mat-icon>{{ viewMode === 'table' ? 'view_module' : 'table_chart' }}</mat-icon>
       </button>
 
@@ -98,7 +99,7 @@
   </div>
 
   @if (advancedFilterColumn !== 'all') {
-    <div class="text-sm text-gray-500 mt-1 ml-60 flex items-center">
+    <div class="text-xs sm:text-sm text-gray-500 mt-2 flex items-center gap-1">
       <mat-icon class="!text-sm mr-1">filter_alt</mat-icon>
       {{ t('search.filtering_in') }}
       <span class="font-medium ml-1">{{ t('search.columns.' + advancedFilterColumn) }}</span>
@@ -106,8 +107,8 @@
   }
 </div>
 
-<div class="bg-white flex shadow-md justify-center gap-5 rounded-lg p-4 mt-4" *transloco="let t">
-  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-gray-200 p-1">
+<div class="bg-white border border-gray-200 flex flex-col sm:flex-row items-center shadow-sm justify-between gap-3 rounded-xl p-3 md:p-4 mt-4" *transloco="let t">
+  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-gray-200 p-1 shadow-sm">
     <mat-button-toggle value="coming" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'coming'">
       {{ t('anniversary.coming') }}
     </mat-button-toggle>
@@ -116,11 +117,11 @@
     </mat-button-toggle>
   </mat-button-toggle-group>
 
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 text-sm md:text-base">
     <mat-icon class="text-gray-500">calendar_today</mat-icon>
     <span class="font-medium text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
   </div>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 text-sm md:text-base">
     <mat-icon class="text-gray-500">schedule</mat-icon>
     <span class="font-medium text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
   </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -1,4 +1,4 @@
-<div class="flex h-screen w-full overflow-hidden bg-gray-200">
+<div class="flex h-screen w-full overflow-hidden bg-gradient-to-br from-slate-100 via-indigo-50/60 to-slate-100">
   <app-aside-nav-bar class="h-full shrink-0"></app-aside-nav-bar>
 
   <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -29,7 +29,7 @@
         (activeButtonChange)="activeButtonChange.emit($event)"
       ></app-landing-page-header>
 
-      <div class="flex-1 overflow-hidden mt-4 rounded-xl bg-white shadow-sm border border-gray-200 flex flex-col">
+      <div class="flex-1 overflow-hidden mt-4 rounded-2xl bg-white/95 shadow-md border border-gray-200/80 backdrop-blur-sm flex flex-col">
         <app-landing-page-content
           class="flex-1 flex flex-col min-h-0" 
           [isLoading]="isLoading"

--- a/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/landing-page-view.component.html
@@ -2,9 +2,7 @@
   <app-aside-nav-bar class="h-full shrink-0"></app-aside-nav-bar>
 
   <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
-    
-    <main class="flex-1 flex flex-col p-4 overflow-hidden">
-      
+    <main class="flex-1 flex flex-col px-3 py-3 md:px-5 md:py-4 overflow-hidden">
       <app-landing-page-header
         class="shrink-0"
         [viewMode]="viewMode"
@@ -31,7 +29,7 @@
         (activeButtonChange)="activeButtonChange.emit($event)"
       ></app-landing-page-header>
 
-      <div class="flex-1 overflow-hidden mt-4 rounded-lg bg-white shadow-sm flex flex-col">
+      <div class="flex-1 overflow-hidden mt-4 rounded-xl bg-white shadow-sm border border-gray-200 flex flex-col">
         <app-landing-page-content
           class="flex-1 flex flex-col min-h-0" 
           [isLoading]="isLoading"
@@ -47,7 +45,6 @@
       </div>
 
       <app-footer class="shrink-0 pt-4"></app-footer>
-      
     </main>
   </div>
 </div>

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -370,6 +370,39 @@ mat-dialog-content,
   border: 1px solid var(--border-color);
   border-radius: 0.75rem;
 }
+
+.dashboard-icon-btn {
+  border-radius: 0.75rem !important;
+  border: 1px solid var(--border-color);
+  background-color: color-mix(in srgb, var(--bg-primary) 84%, transparent);
+  transition: all 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--bg-secondary) !important;
+    border-color: var(--accent-color);
+    transform: translateY(-1px);
+  }
+}
+
+.dashboard-action-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 0.4rem;
+  border: 1px solid var(--border-color) !important;
+  background-color: color-mix(in srgb, var(--bg-primary) 95%, var(--accent-color) 5%) !important;
+  color: var(--text-primary) !important;
+  border-radius: 0.6rem !important;
+  padding: 0.45rem 0.8rem !important;
+  font-weight: 600 !important;
+  transition: all 0.2s ease !important;
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--bg-secondary) !important;
+    border-color: var(--accent-color) !important;
+  }
+}
 //styles pour le background du paginator
 .mdc-list-item--selected {
   background-color: var(--pg-selected) !important;

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -28,24 +28,30 @@ body {
 // Variables pour les thèmes
 :root {
   // Light Theme
-  --light-bg-primary: #ffffff;
-  --light-bg-secondary: #f3f4f6;
-  --light-bg-tertiary: #e5e7eb;
-  --light-text-primary: #111827;
-  --light-text-secondary: #6b7280;
-  --light-border: #e5e7eb;
-  --light-accent: #3b82f6;
+  --light-bg-primary: #f8fafc;
+  --light-bg-secondary: #eef2ff;
+  --light-bg-tertiary: #e2e8f0;
+  --light-text-primary: #0f172a;
+  --light-text-secondary: #475569;
+  --light-border: #cbd5e1;
+  --light-accent: #6366f1;
+  --light-primary: #4f46e5;
+  --light-success: #16a34a;
+  --light-warning: #f59e0b;
   --light-bg-hover: #0D0D0D0D;
   --light-pg-selected: #050c14;
   --light-bg: #F9FAFB;
   // Dark Theme
-  --dark-bg-primary: #1a1a1a;
-  --dark-bg-secondary: #2d2d2d;
-  --dark-bg-tertiary: #3d3d3d;
-  --dark-text-primary: #f5f5f5;
-  --dark-text-secondary: #b0b0b0;
-  --dark-border: #4d4d4d;
-  --dark-accent: #5d9cf8;
+  --dark-bg-primary: #0f172a;
+  --dark-bg-secondary: #1e293b;
+  --dark-bg-tertiary: #334155;
+  --dark-text-primary: #e2e8f0;
+  --dark-text-secondary: #94a3b8;
+  --dark-border: #475569;
+  --dark-accent: #818cf8;
+  --dark-primary: #a5b4fc;
+  --dark-success: #4ade80;
+  --dark-warning: #fbbf24;
   --dark-bg-hover: #FFFFFF14;
   --dark-pg-selected: #ffffff;
   --dark-bg:#4d4d4d;
@@ -57,6 +63,9 @@ body {
   --text-secondary: var(--light-text-secondary);
   --border-color: var(--light-border);
   --accent-color: var(--light-accent);
+  --primary-color: var(--light-primary);
+  --success-color: var(--light-success);
+  --warning-color: var(--light-warning);
   --hover-color: var(--light-bg-hover);
   --pg-selected: var(--light-pg-selected);
   --bg-selected: var(--light-bg);
@@ -71,6 +80,9 @@ body {
   --text-secondary: var(--dark-text-secondary);
   --border-color: var(--dark-border);
   --accent-color: var(--dark-accent);
+  --primary-color: var(--dark-primary);
+  --success-color: var(--dark-success);
+  --warning-color: var(--dark-warning);
   --hover-color: var(--dark-bg-hover);
   --pg-selected: var(--dark-pg-selected);
   --bg-selected: var(--dark-bg);
@@ -351,6 +363,12 @@ mat-dialog-content,
 // Correction spécifique pour le header du tableau
 .mat-header-row {
   background-color: var(--bg-secondary) !important;
+}
+
+.app-surface {
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
 }
 //styles pour le background du paginator
 .mdc-list-item--selected {


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy, spacing and responsiveness across the landing dashboard while preserving existing Angular Material structure.
- Provide a softer, more consistent light/dark design system and clearer micro-interactions for better usability and accessibility.
- Make progressive, non-breaking UI improvements to the header, sidebar, table, content area and footer so current flows remain intact.

### Description
- Expanded the theme token set and refined light/dark colors in `src/styles.scss`, adding `--primary-color`, `--success-color`, and `--warning-color` and softer surface tones for both modes.
- Polished the landing page shell and header by updating spacing, container radii and search affordances and adding `aria-label` attributes to icon-only controls in `pages/landing-page/landing-page-view/*` and `landing-page-header`.
- Upgraded the birthday table in `components/birthday-table/birthday-table.component.html` to support horizontal overflow (`min-w-[860px]`), stronger header hierarchy (uppercase + tracking), zebra stripes, hover transitions, and pill-style badges for category/age/status while fixing the delete click target to the icon button.
- Improved sidebar active-state visibility and interactions by adding an `activeItem` signal and highlight classes in `components/aside-nav-bar/*`, and refreshed footer action styles in `components/footer/footer.component.html` for consistent hover feedback.

### Testing
- Ran `npm run build` in the `front-end` project which failed due to external font inlining being blocked (Google Fonts returned HTTP 403) and is environment-specific, not related to the UI changes.
- Ran `npm run lint` in the `front-end` project which reported pre-existing lint errors in files unrelated to this UI pass, so no new lint-category regressions were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5448eab748332ac6fc8a07121e8c8)