### PR TITLE
Refactor dashboard header into smart container + reusable presentational components

### DIFF
--- a/front-end/public/assets/i18n/de.json
+++ b/front-end/public/assets/i18n/de.json
@@ -39,6 +39,8 @@
   "dashboard_header": {
     "title": "Geburtstage",
     "add_birthday": "Geburtstag hinzufügen",
+    "hide_section": "Ausblenden",
+    "show_section": "Einblenden",
     "subtitle_coming": "Demnächst anstehend",
     "subtitle_passed": "Vergangene Geburtstage",
     "toggle": {

--- a/front-end/public/assets/i18n/de.json
+++ b/front-end/public/assets/i18n/de.json
@@ -48,8 +48,9 @@
     "stats": {
       "weekly": "Geburtstage diese Woche",
       "today": "Heute",
-      "next_7_days": "In den nächsten 7 Tagen",
-      "total_contacts": "Kontakte gesamt"
+      "next_14_days": "In den nächsten 14 Tagen",
+      "total_contacts": "Kontakte gesamt",
+      "counter": "{{count}} Geburtstag(e)"
     }
   },
   "actions": {

--- a/front-end/public/assets/i18n/de.json
+++ b/front-end/public/assets/i18n/de.json
@@ -36,6 +36,22 @@
     "empty_coming": "Kein bevorstehender Geburtstag",
     "empty_passed": "Kein vergangener Geburtstag"
   },
+  "dashboard_header": {
+    "title": "Geburtstage",
+    "add_birthday": "Geburtstag hinzufügen",
+    "subtitle_coming": "Demnächst anstehend",
+    "subtitle_passed": "Vergangene Geburtstage",
+    "toggle": {
+      "coming": "Bevorstehend",
+      "passed": "Vergangen"
+    },
+    "stats": {
+      "weekly": "Geburtstage diese Woche",
+      "today": "Heute",
+      "next_7_days": "In den nächsten 7 Tagen",
+      "total_contacts": "Kontakte gesamt"
+    }
+  },
   "actions": {
     "import": "Importieren",
     "export": "Exportieren"

--- a/front-end/public/assets/i18n/en.json
+++ b/front-end/public/assets/i18n/en.json
@@ -36,6 +36,22 @@
     "empty_coming": "No coming anniversary",
     "empty_passed": "No passed anniversary"
   },
+  "dashboard_header": {
+    "title": "Birthdays",
+    "add_birthday": "Add birthday",
+    "subtitle_coming": "Coming up soon",
+    "subtitle_passed": "Past birthdays",
+    "toggle": {
+      "coming": "Upcoming",
+      "passed": "Past"
+    },
+    "stats": {
+      "weekly": "Birthdays this week",
+      "today": "Today",
+      "next_7_days": "In the next 7 days",
+      "total_contacts": "Total contacts"
+    }
+  },
   "actions": {
     "import": "Import",
     "export": "Export"

--- a/front-end/public/assets/i18n/en.json
+++ b/front-end/public/assets/i18n/en.json
@@ -48,8 +48,9 @@
     "stats": {
       "weekly": "Birthdays this week",
       "today": "Today",
-      "next_7_days": "In the next 7 days",
-      "total_contacts": "Total contacts"
+      "next_14_days": "In the next 14 days",
+      "total_contacts": "Total contacts",
+      "counter": "{{count}} birthday(ies)"
     }
   },
   "actions": {

--- a/front-end/public/assets/i18n/en.json
+++ b/front-end/public/assets/i18n/en.json
@@ -39,6 +39,8 @@
   "dashboard_header": {
     "title": "Birthdays",
     "add_birthday": "Add birthday",
+    "hide_section": "Hide",
+    "show_section": "Show",
     "subtitle_coming": "Coming up soon",
     "subtitle_passed": "Past birthdays",
     "toggle": {

--- a/front-end/public/assets/i18n/fr.json
+++ b/front-end/public/assets/i18n/fr.json
@@ -48,8 +48,9 @@
     "stats": {
       "weekly": "Anniversaires cette semaine",
       "today": "Aujourd’hui",
-      "next_7_days": "Dans les 7 prochains jours",
-      "total_contacts": "Total des contacts"
+      "next_14_days": "Dans les 14 prochains jours",
+      "total_contacts": "Total des contacts",
+      "counter": "{{count}} anniversaire(s)"
     }
   },
   "actions": {

--- a/front-end/public/assets/i18n/fr.json
+++ b/front-end/public/assets/i18n/fr.json
@@ -39,6 +39,8 @@
   "dashboard_header": {
     "title": "Anniversaires",
     "add_birthday": "Ajouter un anniversaire",
+    "hide_section": "Masquer",
+    "show_section": "Afficher",
     "subtitle_coming": "À venir prochainement",
     "subtitle_passed": "Anniversaires passés",
     "toggle": {

--- a/front-end/public/assets/i18n/fr.json
+++ b/front-end/public/assets/i18n/fr.json
@@ -36,6 +36,22 @@
     "empty_coming": "Aucun anniversaire à venir",
     "empty_passed": "Aucun anniversaire passé"
   },
+  "dashboard_header": {
+    "title": "Anniversaires",
+    "add_birthday": "Ajouter un anniversaire",
+    "subtitle_coming": "À venir prochainement",
+    "subtitle_passed": "Anniversaires passés",
+    "toggle": {
+      "coming": "À venir",
+      "passed": "Passés"
+    },
+    "stats": {
+      "weekly": "Anniversaires cette semaine",
+      "today": "Aujourd’hui",
+      "next_7_days": "Dans les 7 prochains jours",
+      "total_contacts": "Total des contacts"
+    }
+  },
   "actions": {
     "import": "Importer",
     "export": "Exporter"

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
@@ -6,28 +6,48 @@
         <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
       </div>
 
-      <button
-        type="button"
-        mat-flat-button
-        class="!rounded-md !bg-gradient-to-r !from-teal-700 !to-cyan-700 !px-2.5 !py-1 !text-[10px] !font-semibold !text-white !shadow-sm hover:!from-teal-800 hover:!to-cyan-800"
-      >
-        <span class="inline-flex items-center gap-1">
-          <mat-icon class="!h-3 !w-3 !text-sm">add</mat-icon>
-          {{ 'dashboard_header.add_birthday' | transloco }}
-        </span>
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          mat-stroked-button
+          class="!rounded-md !border-slate-300 !px-2.5 !py-1 !text-[10px] !font-semibold !text-slate-700 hover:!bg-slate-100"
+          (click)="toggleStatsVisibility()"
+        >
+          <span class="inline-flex items-center gap-1">
+            <mat-icon class="!h-3 !w-3 !text-sm">{{ isStatsVisible() ? 'visibility_off' : 'visibility' }}</mat-icon>
+            {{
+              (isStatsVisible()
+                ? 'dashboard_header.hide_section'
+                : 'dashboard_header.show_section') | transloco
+            }}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          mat-flat-button
+          class="!rounded-md !bg-gradient-to-r !from-teal-700 !to-cyan-700 !px-2.5 !py-1 !text-[10px] !font-semibold !text-white !shadow-sm hover:!from-teal-800 hover:!to-cyan-800"
+        >
+          <span class="inline-flex items-center gap-1">
+            <mat-icon class="!h-3 !w-3 !text-sm">add</mat-icon>
+            {{ 'dashboard_header.add_birthday' | transloco }}
+          </span>
+        </button>
+      </div>
     </div>
 
-    <p class="text-[11px] font-semibold text-slate-700">
-      {{
-        (activeButton === 'coming'
-          ? 'dashboard_header.subtitle_coming'
-          : 'dashboard_header.subtitle_passed') | transloco
-      }}
-    </p>
+    @if (isStatsVisible()) {
+      <p class="text-[11px] font-semibold text-slate-700">
+        {{
+          (activeButton === 'coming'
+            ? 'dashboard_header.subtitle_coming'
+            : 'dashboard_header.subtitle_passed') | transloco
+        }}
+      </p>
 
-    <div>
-      <app-stats-cards [cards]="statsCards()"></app-stats-cards>
-    </div>
+      <div>
+        <app-stats-cards [cards]="statsCards()"></app-stats-cards>
+      </div>
+    }
   </div>
 </section>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
@@ -1,20 +1,24 @@
-<section class="rounded-2xl bg-white px-4 py-4 shadow-md md:px-6 md:py-5" aria-label="En-tête tableau de bord anniversaires">
+<section class="bg-transparent py-1" aria-label="En-tête tableau de bord anniversaires">
   <div class="flex flex-col gap-3">
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <div class="flex flex-wrap items-center gap-3">
-        <h2 class="text-base font-semibold text-slate-900 md:text-lg">Anniversaires</h2>
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex flex-wrap items-center gap-2.5">
+        <h2 class="text-[15px] font-semibold text-slate-900">Anniversaires</h2>
         <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
       </div>
 
-      <button type="button" mat-flat-button class="!rounded-md !bg-teal-700 !px-3 !py-1.5 !text-xs !font-semibold !text-white hover:!bg-teal-800">
+      <button
+        type="button"
+        mat-flat-button
+        class="!rounded-md !bg-teal-700 !px-2.5 !py-1 !text-[10px] !font-semibold !text-white hover:!bg-teal-800"
+      >
         <span class="inline-flex items-center gap-1">
-          <mat-icon class="!h-4 !w-4 !text-base">add</mat-icon>
+          <mat-icon class="!h-3 !w-3 !text-sm">add</mat-icon>
           Ajouter un anniversaire
         </span>
       </button>
     </div>
 
-    <p class="text-xs font-semibold text-slate-700 md:text-sm">{{ subtitle }}</p>
+    <p class="text-[11px] font-semibold text-slate-700">{{ subtitle }}</p>
 
     <div>
       <app-stats-cards [cards]="statsCards()"></app-stats-cards>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
@@ -2,23 +2,29 @@
   <div class="flex flex-col gap-3">
     <div class="flex flex-wrap items-center justify-between gap-2">
       <div class="flex flex-wrap items-center gap-2.5">
-        <h2 class="text-[15px] font-semibold text-slate-900">Anniversaires</h2>
+        <h2 class="text-[15px] font-semibold text-slate-900">{{ 'dashboard_header.title' | transloco }}</h2>
         <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
       </div>
 
       <button
         type="button"
         mat-flat-button
-        class="!rounded-md !bg-teal-700 !px-2.5 !py-1 !text-[10px] !font-semibold !text-white hover:!bg-teal-800"
+        class="!rounded-md !bg-gradient-to-r !from-teal-700 !to-cyan-700 !px-2.5 !py-1 !text-[10px] !font-semibold !text-white !shadow-sm hover:!from-teal-800 hover:!to-cyan-800"
       >
         <span class="inline-flex items-center gap-1">
           <mat-icon class="!h-3 !w-3 !text-sm">add</mat-icon>
-          Ajouter un anniversaire
+          {{ 'dashboard_header.add_birthday' | transloco }}
         </span>
       </button>
     </div>
 
-    <p class="text-[11px] font-semibold text-slate-700">{{ subtitle }}</p>
+    <p class="text-[11px] font-semibold text-slate-700">
+      {{
+        (activeButton === 'coming'
+          ? 'dashboard_header.subtitle_coming'
+          : 'dashboard_header.subtitle_passed') | transloco
+      }}
+    </p>
 
     <div>
       <app-stats-cards [cards]="statsCards()"></app-stats-cards>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
@@ -1,0 +1,15 @@
+<section class="rounded-2xl bg-white px-4 py-4 shadow-md md:px-6 md:py-5" aria-label="En-tête tableau de bord anniversaires">
+  <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+    <div class="xl:w-[240px] xl:flex-shrink-0">
+      <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
+    </div>
+
+    <div class="flex-1">
+      <app-stats-cards [cards]="statsCards()"></app-stats-cards>
+    </div>
+
+    <div class="xl:w-[220px] xl:flex-shrink-0 xl:justify-end flex">
+      <app-date-time-display [currentDate]="currentDate"></app-date-time-display>
+    </div>
+  </div>
+</section>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.html
@@ -1,15 +1,23 @@
 <section class="rounded-2xl bg-white px-4 py-4 shadow-md md:px-6 md:py-5" aria-label="En-tête tableau de bord anniversaires">
-  <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-    <div class="xl:w-[240px] xl:flex-shrink-0">
-      <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="flex flex-wrap items-center gap-3">
+        <h2 class="text-base font-semibold text-slate-900 md:text-lg">Anniversaires</h2>
+        <app-toggle-switch [activeMode]="activeButton" (modeChange)="onModeChange($event)"></app-toggle-switch>
+      </div>
+
+      <button type="button" mat-flat-button class="!rounded-md !bg-teal-700 !px-3 !py-1.5 !text-xs !font-semibold !text-white hover:!bg-teal-800">
+        <span class="inline-flex items-center gap-1">
+          <mat-icon class="!h-4 !w-4 !text-base">add</mat-icon>
+          Ajouter un anniversaire
+        </span>
+      </button>
     </div>
 
-    <div class="flex-1">
+    <p class="text-xs font-semibold text-slate-700 md:text-sm">{{ subtitle }}</p>
+
+    <div>
       <app-stats-cards [cards]="statsCards()"></app-stats-cards>
-    </div>
-
-    <div class="xl:w-[220px] xl:flex-shrink-0 xl:justify-end flex">
-      <app-date-time-display [currentDate]="currentDate"></app-date-time-display>
     </div>
   </div>
 </section>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -1,0 +1,94 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+import { BirthdayService } from '../../../../../../../core/services/birthday/birthday.service';
+import { Birthday } from '../../../../../../../models/birthday.model';
+import { LandingFilterMode } from '../../../../../landing-page.component';
+import { ToggleSwitchComponent } from './toggle-switch/toggle-switch.component';
+import { StatsCardsComponent, DashboardStatCard } from './stats-cards/stats-cards.component';
+import { DateTimeDisplayComponent } from './date-time-display/date-time-display.component';
+
+@Component({
+  selector: 'app-birthday-dashboard-header-container',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, ToggleSwitchComponent, StatsCardsComponent, DateTimeDisplayComponent],
+  templateUrl: './birthday-dashboard-header.container.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BirthdayDashboardHeaderContainerComponent {
+  private readonly birthdayService = inject(BirthdayService);
+
+  @Input({ required: true }) activeButton!: LandingFilterMode;
+  @Input({ required: true }) currentDate!: Date;
+
+  @Output() activeButtonChange = new EventEmitter<LandingFilterMode>();
+
+  readonly allBirthdays = computed(() => this.birthdayService.birthdays());
+
+  readonly statsCards = computed<DashboardStatCard[]>(() => {
+    const birthdays = this.allBirthdays();
+
+    return [
+      {
+        id: 'weekly',
+        label: 'Anniversaires cette semaine',
+        value: this.countBirthdaysInRange(birthdays, 0, 6),
+        icon: 'cake',
+        iconClass: 'text-indigo-600',
+        cardClass: 'bg-indigo-50 border-indigo-100',
+      },
+      {
+        id: 'today',
+        label: 'Aujourd’hui',
+        value: this.countBirthdaysInRange(birthdays, 0, 0),
+        icon: 'celebration',
+        iconClass: 'text-rose-600',
+        cardClass: 'bg-rose-50 border-rose-100',
+      },
+      {
+        id: 'next-7-days',
+        label: 'Dans les 7 prochains jours',
+        value: this.countBirthdaysInRange(birthdays, 1, 7),
+        icon: 'event_available',
+        iconClass: 'text-blue-600',
+        cardClass: 'bg-blue-50 border-blue-100',
+      },
+      {
+        id: 'total',
+        label: 'Total des contacts',
+        value: birthdays.length,
+        icon: 'groups',
+        iconClass: 'text-violet-600',
+        cardClass: 'bg-violet-50 border-violet-100',
+      },
+    ];
+  });
+
+  onModeChange(mode: LandingFilterMode): void {
+    this.activeButtonChange.emit(mode);
+  }
+
+  private countBirthdaysInRange(birthdays: Birthday[], minDays: number, maxDays: number): number {
+    return birthdays.filter((birthday) => {
+      const days = this.getDaysUntilBirthday(birthday.date);
+      return days >= minDays && days <= maxDays;
+    }).length;
+  }
+
+  private getDaysUntilBirthday(date: Date): number {
+    const now = new Date(this.currentDate);
+    now.setHours(0, 0, 0, 0);
+
+    const normalizedDate = new Date(date);
+    normalizedDate.setFullYear(now.getFullYear());
+    normalizedDate.setHours(0, 0, 0, 0);
+
+    if (normalizedDate < now) {
+      normalizedDate.setFullYear(now.getFullYear() + 1);
+    }
+
+    const diffMs = normalizedDate.getTime() - now.getTime();
+    return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  }
+}

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -24,6 +24,7 @@ export class BirthdayDashboardHeaderContainerComponent {
   @Input({ required: true }) currentDate!: Date;
 
   @Output() activeButtonChange = new EventEmitter<LandingFilterMode>();
+  readonly isStatsVisible = signal(true);
 
   readonly allBirthdays = computed(() => this.birthdayService.birthdays());
 
@@ -72,6 +73,10 @@ export class BirthdayDashboardHeaderContainerComponent {
 
   onModeChange(mode: LandingFilterMode): void {
     this.activeButtonChange.emit(mode);
+  }
+
+  toggleStatsVisibility(): void {
+    this.isStatsVisible.update((visible) => !visible);
   }
 
   private countBirthdaysInRange(birthdays: Birthday[], minDays: number, maxDays: number): number {

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -36,7 +36,7 @@ export class BirthdayDashboardHeaderContainerComponent {
         value: this.countBirthdaysInRange(birthdays, 0, 6),
         icon: 'cake',
         iconClass: 'text-indigo-600',
-        cardClass: 'bg-indigo-50 border-indigo-100',
+        cardClass: '',
       },
       {
         id: 'today',
@@ -44,7 +44,7 @@ export class BirthdayDashboardHeaderContainerComponent {
         value: this.countBirthdaysInRange(birthdays, 0, 0),
         icon: 'celebration',
         iconClass: 'text-rose-600',
-        cardClass: 'bg-rose-50 border-rose-100',
+        cardClass: '',
       },
       {
         id: 'next-7-days',
@@ -52,7 +52,7 @@ export class BirthdayDashboardHeaderContainerComponent {
         value: this.countBirthdaysInRange(birthdays, 1, 7),
         icon: 'event_available',
         iconClass: 'text-blue-600',
-        cardClass: 'bg-blue-50 border-blue-100',
+        cardClass: '',
       },
       {
         id: 'total',
@@ -60,7 +60,7 @@ export class BirthdayDashboardHeaderContainerComponent {
         value: birthdays.length,
         icon: 'groups',
         iconClass: 'text-violet-600',
-        cardClass: 'bg-violet-50 border-violet-100',
+        cardClass: '',
       },
     ];
   });

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -31,7 +31,7 @@ export class BirthdayDashboardHeaderContainerComponent {
     const birthdays = this.allBirthdays();
     const weeklyCount = this.countBirthdaysInRange(birthdays, 0, 6);
     const todayCount = this.countBirthdaysInRange(birthdays, 0, 0);
-    const nextSevenDaysCount = this.countBirthdaysInRange(birthdays, 1, 7);
+    const nextFourteenDaysCount = this.countBirthdaysInRange(birthdays, 1, 14);
     const totalContactsCount = Array.isArray(birthdays) ? birthdays.length : 0;
 
     return [
@@ -52,9 +52,9 @@ export class BirthdayDashboardHeaderContainerComponent {
         cardClass: 'from-rose-50 to-rose-100/40',
       },
       {
-        id: 'next-7-days',
-        labelKey: 'dashboard_header.stats.next_7_days',
-        value: nextSevenDaysCount,
+        id: 'next-14-days',
+        labelKey: 'dashboard_header.stats.next_14_days',
+        value: nextFourteenDaysCount,
         icon: 'event_available',
         iconClass: 'text-blue-600',
         cardClass: 'from-blue-50 to-blue-100/40',

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
 import { BirthdayService } from '../../../../../../../core/services/birthday/birthday.service';
@@ -7,12 +8,11 @@ import { Birthday } from '../../../../../../../models/birthday.model';
 import { LandingFilterMode } from '../../../../../landing-page.component';
 import { ToggleSwitchComponent } from './toggle-switch/toggle-switch.component';
 import { StatsCardsComponent, DashboardStatCard } from './stats-cards/stats-cards.component';
-import { DateTimeDisplayComponent } from './date-time-display/date-time-display.component';
 
 @Component({
   selector: 'app-birthday-dashboard-header-container',
   standalone: true,
-  imports: [CommonModule, MatIconModule, ToggleSwitchComponent, StatsCardsComponent, DateTimeDisplayComponent],
+  imports: [CommonModule, MatButtonModule, MatIconModule, ToggleSwitchComponent, StatsCardsComponent],
   templateUrl: './birthday-dashboard-header.container.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -64,6 +64,10 @@ export class BirthdayDashboardHeaderContainerComponent {
       },
     ];
   });
+
+  get subtitle(): string {
+    return this.activeButton === 'coming' ? 'À venir prochainement' : 'Anniversaires passés';
+  }
 
   onModeChange(mode: LandingFilterMode): void {
     this.activeButtonChange.emit(mode);

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -29,12 +29,16 @@ export class BirthdayDashboardHeaderContainerComponent {
 
   readonly statsCards = computed<DashboardStatCard[]>(() => {
     const birthdays = this.allBirthdays();
+    const weeklyCount = this.countBirthdaysInRange(birthdays, 0, 6);
+    const todayCount = this.countBirthdaysInRange(birthdays, 0, 0);
+    const nextSevenDaysCount = this.countBirthdaysInRange(birthdays, 1, 7);
+    const totalContactsCount = Array.isArray(birthdays) ? birthdays.length : 0;
 
     return [
       {
         id: 'weekly',
         labelKey: 'dashboard_header.stats.weekly',
-        value: this.countBirthdaysInRange(birthdays, 0, 6),
+        value: weeklyCount,
         icon: 'cake',
         iconClass: 'text-indigo-600',
         cardClass: 'from-indigo-50 to-indigo-100/40',
@@ -42,7 +46,7 @@ export class BirthdayDashboardHeaderContainerComponent {
       {
         id: 'today',
         labelKey: 'dashboard_header.stats.today',
-        value: this.countBirthdaysInRange(birthdays, 0, 0),
+        value: todayCount,
         icon: 'celebration',
         iconClass: 'text-rose-600',
         cardClass: 'from-rose-50 to-rose-100/40',
@@ -50,7 +54,7 @@ export class BirthdayDashboardHeaderContainerComponent {
       {
         id: 'next-7-days',
         labelKey: 'dashboard_header.stats.next_7_days',
-        value: this.countBirthdaysInRange(birthdays, 1, 7),
+        value: nextSevenDaysCount,
         icon: 'event_available',
         iconClass: 'text-blue-600',
         cardClass: 'from-blue-50 to-blue-100/40',
@@ -58,7 +62,7 @@ export class BirthdayDashboardHeaderContainerComponent {
       {
         id: 'total',
         labelKey: 'dashboard_header.stats.total_contacts',
-        value: birthdays.length,
+        value: totalContactsCount,
         icon: 'groups',
         iconClass: 'text-violet-600',
         cardClass: 'from-violet-50 to-violet-100/40',
@@ -71,6 +75,10 @@ export class BirthdayDashboardHeaderContainerComponent {
   }
 
   private countBirthdaysInRange(birthdays: Birthday[], minDays: number, maxDays: number): number {
+    if (!Array.isArray(birthdays) || birthdays.length === 0) {
+      return 0;
+    }
+
     return birthdays.filter((birthday) => {
       const days = this.getDaysUntilBirthday(birthday.date);
       return days >= minDays && days <= maxDays;
@@ -78,10 +86,15 @@ export class BirthdayDashboardHeaderContainerComponent {
   }
 
   private getDaysUntilBirthday(date: Date): number {
+    const validDate = this.asValidDate(date);
+    if (!validDate) {
+      return Number.POSITIVE_INFINITY;
+    }
+
     const now = new Date(this.currentDate);
     now.setHours(0, 0, 0, 0);
 
-    const normalizedDate = new Date(date);
+    const normalizedDate = new Date(validDate);
     normalizedDate.setFullYear(now.getFullYear());
     normalizedDate.setHours(0, 0, 0, 0);
 
@@ -91,5 +104,10 @@ export class BirthdayDashboardHeaderContainerComponent {
 
     const diffMs = normalizedDate.getTime() - now.getTime();
     return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  }
+
+  private asValidDate(input: Date): Date | null {
+    const date = new Date(input);
+    return Number.isNaN(date.getTime()) ? null : date;
   }
 }

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/birthday-dashboard-header.container.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, comput
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { TranslocoModule } from '@jsverse/transloco';
 
 import { BirthdayService } from '../../../../../../../core/services/birthday/birthday.service';
 import { Birthday } from '../../../../../../../models/birthday.model';
@@ -12,7 +13,7 @@ import { StatsCardsComponent, DashboardStatCard } from './stats-cards/stats-card
 @Component({
   selector: 'app-birthday-dashboard-header-container',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, ToggleSwitchComponent, StatsCardsComponent],
+  imports: [CommonModule, MatButtonModule, MatIconModule, TranslocoModule, ToggleSwitchComponent, StatsCardsComponent],
   templateUrl: './birthday-dashboard-header.container.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -32,42 +33,38 @@ export class BirthdayDashboardHeaderContainerComponent {
     return [
       {
         id: 'weekly',
-        label: 'Anniversaires cette semaine',
+        labelKey: 'dashboard_header.stats.weekly',
         value: this.countBirthdaysInRange(birthdays, 0, 6),
         icon: 'cake',
         iconClass: 'text-indigo-600',
-        cardClass: '',
+        cardClass: 'from-indigo-50 to-indigo-100/40',
       },
       {
         id: 'today',
-        label: 'Aujourd’hui',
+        labelKey: 'dashboard_header.stats.today',
         value: this.countBirthdaysInRange(birthdays, 0, 0),
         icon: 'celebration',
         iconClass: 'text-rose-600',
-        cardClass: '',
+        cardClass: 'from-rose-50 to-rose-100/40',
       },
       {
         id: 'next-7-days',
-        label: 'Dans les 7 prochains jours',
+        labelKey: 'dashboard_header.stats.next_7_days',
         value: this.countBirthdaysInRange(birthdays, 1, 7),
         icon: 'event_available',
         iconClass: 'text-blue-600',
-        cardClass: '',
+        cardClass: 'from-blue-50 to-blue-100/40',
       },
       {
         id: 'total',
-        label: 'Total des contacts',
+        labelKey: 'dashboard_header.stats.total_contacts',
         value: birthdays.length,
         icon: 'groups',
         iconClass: 'text-violet-600',
-        cardClass: '',
+        cardClass: 'from-violet-50 to-violet-100/40',
       },
     ];
   });
-
-  get subtitle(): string {
-    return this.activeButton === 'coming' ? 'À venir prochainement' : 'Anniversaires passés';
-  }
 
   onModeChange(mode: LandingFilterMode): void {
     this.activeButtonChange.emit(mode);

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/date-time-display/date-time-display.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/date-time-display/date-time-display.component.html
@@ -1,0 +1,11 @@
+<div class="grid w-full gap-2 rounded-2xl bg-slate-50 p-3 text-sm shadow-inner md:w-auto">
+  <div class="flex items-center gap-2 text-slate-700">
+    <mat-icon class="!h-4 !w-4 !text-base">calendar_today</mat-icon>
+    <time [attr.datetime]="currentDate.toISOString()" class="font-semibold">{{ currentDate | date : 'dd.MM.yyyy' }}</time>
+  </div>
+
+  <div class="flex items-center gap-2 text-slate-700">
+    <mat-icon class="!h-4 !w-4 !text-base">schedule</mat-icon>
+    <span class="font-semibold">{{ currentDate | date : 'HH:mm' }}</span>
+  </div>
+</div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/date-time-display/date-time-display.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/date-time-display/date-time-display.component.ts
@@ -1,0 +1,14 @@
+import { DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-date-time-display',
+  standalone: true,
+  imports: [DatePipe, MatIconModule],
+  templateUrl: './date-time-display.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DateTimeDisplayComponent {
+  @Input({ required: true }) currentDate!: Date;
+}

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
@@ -1,0 +1,15 @@
+<div class="grid grid-cols-2 gap-3 lg:grid-cols-4" aria-label="Résumé des statistiques">
+  @for (card of cards; track card.id) {
+    <article
+      class="rounded-2xl border p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+      [ngClass]="card.cardClass"
+      [attr.aria-label]="card.label + ': ' + card.value"
+    >
+      <div class="mb-2 inline-flex rounded-xl bg-white/80 p-2">
+        <mat-icon [ngClass]="card.iconClass">{{ card.icon }}</mat-icon>
+      </div>
+      <p class="text-2xl font-bold text-slate-900">{{ card.value }}</p>
+      <p class="text-xs font-medium text-slate-600">{{ card.label }}</p>
+    </article>
+  }
+</div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
@@ -1,15 +1,15 @@
 <div class="grid grid-cols-2 gap-2 md:grid-cols-4" aria-label="Résumé des statistiques">
   @for (card of cards; track card.id) {
     <article
-      class="rounded-xl border p-3 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+      class="rounded-lg border border-slate-200 bg-white p-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm"
       [ngClass]="card.cardClass"
       [attr.aria-label]="card.label + ': ' + card.value"
     >
-      <div class="mb-2 inline-flex rounded-lg bg-white/90 p-1.5">
-        <mat-icon [ngClass]="card.iconClass" class="!h-4 !w-4 !text-base">{{ card.icon }}</mat-icon>
+      <div class="mb-1 inline-flex rounded-md bg-white p-1">
+        <mat-icon [ngClass]="card.iconClass" class="!h-3.5 !w-3.5 !text-sm">{{ card.icon }}</mat-icon>
       </div>
-      <p class="text-xl font-bold text-slate-900">{{ card.value }}</p>
-      <p class="text-[11px] font-medium text-slate-600">{{ card.label }}</p>
+      <p class="text-lg font-bold leading-5 text-slate-900">{{ card.value }}</p>
+      <p class="text-[10px] font-medium leading-4 text-slate-600">{{ card.label }}</p>
     </article>
   }
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
@@ -1,15 +1,15 @@
 <div class="grid grid-cols-2 gap-2 md:grid-cols-4" aria-label="Résumé des statistiques">
   @for (card of cards; track card.id) {
     <article
-      class="rounded-lg border border-slate-200 bg-white p-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm"
+      class="rounded-lg border border-slate-200 bg-gradient-to-br p-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm"
       [ngClass]="card.cardClass"
-      [attr.aria-label]="card.label + ': ' + card.value"
+      [attr.aria-label]="(card.labelKey | transloco) + ': ' + card.value"
     >
       <div class="mb-1 inline-flex rounded-md bg-white p-1">
         <mat-icon [ngClass]="card.iconClass" class="!h-3.5 !w-3.5 !text-sm">{{ card.icon }}</mat-icon>
       </div>
       <p class="text-lg font-bold leading-5 text-slate-900">{{ card.value }}</p>
-      <p class="text-[10px] font-medium leading-4 text-slate-600">{{ card.label }}</p>
+      <p class="text-[10px] font-medium leading-4 text-slate-600">{{ card.labelKey | transloco }}</p>
     </article>
   }
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
@@ -1,15 +1,15 @@
-<div class="grid grid-cols-2 gap-3 lg:grid-cols-4" aria-label="Résumé des statistiques">
+<div class="grid grid-cols-2 gap-2 md:grid-cols-4" aria-label="Résumé des statistiques">
   @for (card of cards; track card.id) {
     <article
-      class="rounded-2xl border p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+      class="rounded-xl border p-3 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
       [ngClass]="card.cardClass"
       [attr.aria-label]="card.label + ': ' + card.value"
     >
-      <div class="mb-2 inline-flex rounded-xl bg-white/80 p-2">
-        <mat-icon [ngClass]="card.iconClass">{{ card.icon }}</mat-icon>
+      <div class="mb-2 inline-flex rounded-lg bg-white/90 p-1.5">
+        <mat-icon [ngClass]="card.iconClass" class="!h-4 !w-4 !text-base">{{ card.icon }}</mat-icon>
       </div>
-      <p class="text-2xl font-bold text-slate-900">{{ card.value }}</p>
-      <p class="text-xs font-medium text-slate-600">{{ card.label }}</p>
+      <p class="text-xl font-bold text-slate-900">{{ card.value }}</p>
+      <p class="text-[11px] font-medium text-slate-600">{{ card.label }}</p>
     </article>
   }
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.html
@@ -10,6 +10,7 @@
       </div>
       <p class="text-lg font-bold leading-5 text-slate-900">{{ card.value }}</p>
       <p class="text-[10px] font-medium leading-4 text-slate-600">{{ card.labelKey | transloco }}</p>
+      <p class="mt-0.5 text-[10px] text-slate-500">{{ 'dashboard_header.stats.counter' | transloco: { count: card.value } }}</p>
     </article>
   }
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+export interface DashboardStatCard {
+  id: string;
+  label: string;
+  value: number;
+  icon: string;
+  iconClass: string;
+  cardClass: string;
+}
+
+@Component({
+  selector: 'app-stats-cards',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './stats-cards.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StatsCardsComponent {
+  @Input({ required: true }) cards: DashboardStatCard[] = [];
+}

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/stats-cards/stats-cards.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import { TranslocoModule } from '@jsverse/transloco';
 
 export interface DashboardStatCard {
   id: string;
-  label: string;
+  labelKey: string;
   value: number;
   icon: string;
   iconClass: string;
@@ -14,7 +15,7 @@ export interface DashboardStatCard {
 @Component({
   selector: 'app-stats-cards',
   standalone: true,
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatIconModule, TranslocoModule],
   templateUrl: './stats-cards.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
@@ -1,0 +1,32 @@
+<div class="inline-flex w-full rounded-full bg-slate-100 p-1" role="tablist" aria-label="Filtrer les anniversaires">
+  <button
+    type="button"
+    class="flex-1 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    [class.bg-white]="activeMode === 'coming'"
+    [class.text-teal-700]="activeMode === 'coming'"
+    [class.shadow-sm]="activeMode === 'coming'"
+    [attr.aria-selected]="activeMode === 'coming'"
+    role="tab"
+    (click)="select('coming')"
+  >
+    <span class="inline-flex items-center gap-1.5">
+      @if (activeMode === 'coming') {
+        <mat-icon class="!h-4 !w-4 !text-base">done</mat-icon>
+      }
+      À venir
+    </span>
+  </button>
+
+  <button
+    type="button"
+    class="flex-1 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    [class.bg-white]="activeMode === 'passed'"
+    [class.text-slate-800]="activeMode === 'passed'"
+    [class.shadow-sm]="activeMode === 'passed'"
+    [attr.aria-selected]="activeMode === 'passed'"
+    role="tab"
+    (click)="select('passed')"
+  >
+    Passés
+  </button>
+</div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
@@ -1,7 +1,7 @@
 <div class="inline-flex rounded-md bg-slate-100 p-0.5" role="tablist" aria-label="Filtrer les anniversaires">
   <button
     type="button"
-    class="rounded-md px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    class="rounded-[5px] px-2 py-1 text-[10px] font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
     [class.bg-emerald-50]="activeMode === 'coming'"
     [class.text-teal-700]="activeMode === 'coming'"
     [class.shadow-sm]="activeMode === 'coming'"
@@ -9,9 +9,9 @@
     role="tab"
     (click)="select('coming')"
   >
-    <span class="inline-flex items-center gap-1">
+    <span class="inline-flex items-center gap-0.5">
       @if (activeMode === 'coming') {
-        <mat-icon class="!h-3.5 !w-3.5 !text-sm">done</mat-icon>
+        <mat-icon class="!h-3 !w-3 !text-[10px]">done</mat-icon>
       }
       À venir
     </span>
@@ -19,7 +19,7 @@
 
   <button
     type="button"
-    class="rounded-md px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    class="rounded-[5px] px-2 py-1 text-[10px] font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
     [class.bg-white]="activeMode === 'passed'"
     [class.text-slate-800]="activeMode === 'passed'"
     [class.shadow-sm]="activeMode === 'passed'"

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
@@ -13,7 +13,7 @@
       @if (activeMode === 'coming') {
         <mat-icon class="!h-3 !w-3 !text-[10px]">done</mat-icon>
       }
-      À venir
+      {{ 'dashboard_header.toggle.coming' | transloco }}
     </span>
   </button>
 
@@ -27,6 +27,6 @@
     role="tab"
     (click)="select('passed')"
   >
-    Passés
+    {{ 'dashboard_header.toggle.passed' | transloco }}
   </button>
 </div>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.html
@@ -1,17 +1,17 @@
-<div class="inline-flex w-full rounded-full bg-slate-100 p-1" role="tablist" aria-label="Filtrer les anniversaires">
+<div class="inline-flex rounded-md bg-slate-100 p-0.5" role="tablist" aria-label="Filtrer les anniversaires">
   <button
     type="button"
-    class="flex-1 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-    [class.bg-white]="activeMode === 'coming'"
+    class="rounded-md px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    [class.bg-emerald-50]="activeMode === 'coming'"
     [class.text-teal-700]="activeMode === 'coming'"
     [class.shadow-sm]="activeMode === 'coming'"
     [attr.aria-selected]="activeMode === 'coming'"
     role="tab"
     (click)="select('coming')"
   >
-    <span class="inline-flex items-center gap-1.5">
+    <span class="inline-flex items-center gap-1">
       @if (activeMode === 'coming') {
-        <mat-icon class="!h-4 !w-4 !text-base">done</mat-icon>
+        <mat-icon class="!h-3.5 !w-3.5 !text-sm">done</mat-icon>
       }
       À venir
     </span>
@@ -19,7 +19,7 @@
 
   <button
     type="button"
-    class="flex-1 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+    class="rounded-md px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
     [class.bg-white]="activeMode === 'passed'"
     [class.text-slate-800]="activeMode === 'passed'"
     [class.shadow-sm]="activeMode === 'passed'"

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+import { LandingFilterMode } from '../../../../../../landing-page.component';
+
+@Component({
+  selector: 'app-toggle-switch',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './toggle-switch.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ToggleSwitchComponent {
+  @Input({ required: true }) activeMode!: LandingFilterMode;
+
+  @Output() modeChange = new EventEmitter<LandingFilterMode>();
+
+  select(mode: LandingFilterMode): void {
+    if (this.activeMode !== mode) {
+      this.modeChange.emit(mode);
+    }
+  }
+}

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/components/dashboard-header/toggle-switch/toggle-switch.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import { TranslocoModule } from '@jsverse/transloco';
 
 import { LandingFilterMode } from '../../../../../../landing-page.component';
 
 @Component({
   selector: 'app-toggle-switch',
   standalone: true,
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatIconModule, TranslocoModule],
   templateUrl: './toggle-switch.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.html
@@ -106,22 +106,9 @@
   }
 </div>
 
-<div class="bg-white flex shadow-md justify-center gap-5 rounded-lg p-4 mt-4" *transloco="let t">
-  <mat-button-toggle-group [value]="activeButton" (change)="activeButtonChange.emit($event.value)" class="!border-none rounded-full bg-gray-200 p-1">
-    <mat-button-toggle value="coming" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'coming'">
-      {{ t('anniversary.coming') }}
-    </mat-button-toggle>
-    <mat-button-toggle value="passed" class="!rounded-full !font-medium !px-4 !py-2 !border-none" [class.!bg-white]="activeButton === 'passed'">
-      {{ t('anniversary.passed') }}
-    </mat-button-toggle>
-  </mat-button-toggle-group>
-
-  <div class="flex items-center gap-2">
-    <mat-icon class="text-gray-500">calendar_today</mat-icon>
-    <span class="font-medium text-gray-800">{{ currentDate | date : 'dd.MM.yyyy' }}</span>
-  </div>
-  <div class="flex items-center gap-2">
-    <mat-icon class="text-gray-500">schedule</mat-icon>
-    <span class="font-medium text-gray-800">{{ currentDate | date : 'HH:mm' }}</span>
-  </div>
-</div>
+<app-birthday-dashboard-header-container
+  class="mt-4 block"
+  [activeButton]="activeButton"
+  [currentDate]="currentDate"
+  (activeButtonChange)="activeButtonChange.emit($event)"
+></app-birthday-dashboard-header-container>

--- a/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.ts
+++ b/front-end/src/app/pages/landing-page/landing-page-view/components/landing-page-header/landing-page-header.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, DatePipe, NgClass } from '@angular/common';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
@@ -7,7 +7,6 @@ import { TranslocoModule } from '@jsverse/transloco';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -17,6 +16,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { SetLanguageComponent } from '../../../../../components/set-language/set-language.component';
 import { UserProfile } from '../../../../../models/user.model';
 import type { LandingFilterMode, LandingViewMode } from '../../../landing-page.component';
+import { BirthdayDashboardHeaderContainerComponent } from './components/dashboard-header/birthday-dashboard-header.container';
 
 @Component({
   selector: 'app-landing-page-header',
@@ -28,7 +28,6 @@ import type { LandingFilterMode, LandingViewMode } from '../../../landing-page.c
     MatAutocompleteModule,
     MatBadgeModule,
     MatButtonModule,
-    MatButtonToggleModule,
     MatDividerModule,
     MatIconModule,
     MatInputModule,
@@ -37,9 +36,11 @@ import type { LandingFilterMode, LandingViewMode } from '../../../landing-page.c
     NgClass,
     RouterLink,
     SetLanguageComponent,
+    BirthdayDashboardHeaderContainerComponent,
     TranslocoModule,
   ],
   templateUrl: './landing-page-header.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LandingPageHeaderComponent {
   @Input({ required: true }) viewMode!: LandingViewMode;


### PR DESCRIPTION
### Motivation
- Replace the legacy `filter + date + toggle` strip in the landing header with a modern dashboard header that surfaces segmented mode, date/time, and summary stats without touching page-level routing or services. 
- Respect existing architecture constraints (Container/Presentational pattern, OnPush change detection, lazy-loading, and compatibility with current models/APIs).

### Description
- Added a smart container `BirthdayDashboardHeaderContainerComponent` that reads from `BirthdayService`, computes KPI counts (this week, today, next 7 days, total) and emits mode changes via `activeButtonChange`.
- Implemented three reusable presentational components: `ToggleSwitchComponent` (Upcoming/Passés segmented control), `StatsCardsComponent` (typed 4-card summary with icons/colors), and `DateTimeDisplayComponent` (date + time block), all using `@Input()`/`@Output()` and `ChangeDetectionStrategy.OnPush`.
- Replaced the old strip in `landing-page-header.component.html` with `<app-birthday-dashboard-header-container>` and imported the new container into `landing-page-header.component.ts`, enabling `OnPush` for that header component to reduce re-renders.
- Kept routing and services untouched (`/dashboard` remains loaded via existing `loadComponent`) and used existing `Birthday` model and `LandingFilterMode` to preserve compatibility.

### Testing
- Type-check: `npx tsc --noEmit -p front-end/tsconfig.app.json` completed successfully.
- Project build: `npm run build` for the frontend failed in this environment due to Google Fonts inlining returning `403` (environmental issue unrelated to the UI refactor).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2f1580c083329012bfc36c93fe83)